### PR TITLE
Add `ftml!` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ tdoc provides a comprehensive toolkit for working with FTML documents in Rust:
   - **Markdown**: Export FTML documents to Markdown for compatibility with documentation systems
   - **HTML**: Import HTML documents into FTML (basic support), with plans for full HTML export
 - **Document Manipulation**: Build and modify FTML documents programmatically with a clean, type-safe API
+- **Inline FTML macro**: Compose FTML document trees inline with the `ftml!` macro for ergonomic test fixtures and examples
 - **Command-line Tools**: Ready-to-use CLI utilities for viewing, converting, and formatting FTML documents
 
 ## Document Structure
@@ -114,6 +115,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Write to stdout
     write(&mut stdout(), &doc)?;
 
+    Ok(())
+}
+```
+
+### Building with the `ftml!` macro
+
+```rust
+use tdoc::{ftml, write};
+
+fn main() -> tdoc::Result<()> {
+    // Compose a document inline, similar to RSX or JSX
+    let doc = ftml! {
+        h1 { "Hello World!" }
+        ul {
+            li {
+                p { "This is a text paragraph inside a list item" }
+                quote { p { "And this is a quoted paragraph in the same item" } }
+            }
+        }
+        p { "Inline styles work " b { "just as well" } "." }
+    };
+
+    write(&mut std::io::stdout(), &doc)?;
     Ok(())
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod macros;
+
 pub mod document;
 pub mod formatter;
 pub mod html;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,177 @@
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_collect_blocks {
+    () => {
+        ::std::vec::Vec::<$crate::Paragraph>::new()
+    };
+    ($($tt:tt)*) => {{
+        let mut __blocks: ::std::vec::Vec<$crate::Paragraph> = ::std::vec::Vec::new();
+        __ftml_collect_blocks_inner!(__blocks, $($tt)*);
+        __blocks
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_collect_blocks_inner {
+    ($vec:ident,) => {};
+    ($vec:ident) => {};
+    ($vec:ident, , $($rest:tt)*) => {
+        __ftml_collect_blocks_inner!($vec, $($rest)*);
+    };
+    ($vec:ident, $tag:ident { $($inner:tt)* } $($rest:tt)*) => {{
+        $vec.push(__ftml_build_block!($tag { $($inner)* }));
+        __ftml_collect_blocks_inner!($vec, $($rest)*);
+    }};
+    ($vec:ident, $unexpected:tt $($rest:tt)*) => {{
+        compile_error!(concat!(
+            "Unexpected token in FTML block context: ",
+            stringify!($unexpected)
+        ));
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_build_block {
+    (p { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_text().with_content(__ftml_inline_nodes!($($inner)*))
+    }};
+    (h1 { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_header1().with_content(__ftml_inline_nodes!($($inner)*))
+    }};
+    (h2 { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_header2().with_content(__ftml_inline_nodes!($($inner)*))
+    }};
+    (h3 { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_header3().with_content(__ftml_inline_nodes!($($inner)*))
+    }};
+    (quote { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_quote().with_children(__ftml_collect_blocks!($($inner)*))
+    }};
+    (ul { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_unordered_list().with_entries(__ftml_list_entries!($($inner)*))
+    }};
+    (ol { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_ordered_list().with_entries(__ftml_list_entries!($($inner)*))
+    }};
+    ($other:ident { $($inner:tt)* }) => {{
+        compile_error!(concat!("Unknown FTML element: ", stringify!($other)));
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_inline_nodes {
+    () => {
+        ::std::vec::Vec::<$crate::Span>::new()
+    };
+    ($($tt:tt)*) => {{
+        let mut __spans: ::std::vec::Vec<$crate::Span> = ::std::vec::Vec::new();
+        __ftml_inline_nodes_inner!(__spans, $($tt)*);
+        __spans
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_inline_nodes_inner {
+    ($vec:ident,) => {};
+    ($vec:ident) => {};
+    ($vec:ident, , $($rest:tt)*) => {
+        __ftml_inline_nodes_inner!($vec, $($rest)*);
+    };
+    ($vec:ident, $tag:ident { $($inner:tt)* } $($rest:tt)*) => {{
+        $vec.push(__ftml_build_inline!($tag { $($inner)* }));
+        __ftml_inline_nodes_inner!($vec, $($rest)*);
+    }};
+    ($vec:ident, $lit:literal $($rest:tt)*) => {{
+        $vec.push($crate::Span::new_text($lit));
+        __ftml_inline_nodes_inner!($vec, $($rest)*);
+    }};
+    ($vec:ident, ($($expr:tt)*) $($rest:tt)*) => {{
+        $vec.push($crate::Span::new_text(($($expr)*)));
+        __ftml_inline_nodes_inner!($vec, $($rest)*);
+    }};
+    ($vec:ident, $ident:ident $($rest:tt)*) => {{
+        $vec.push($crate::Span::new_text($ident));
+        __ftml_inline_nodes_inner!($vec, $($rest)*);
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_build_inline {
+    (b { $($inner:tt)* }) => {{
+        $crate::Span::new_styled($crate::InlineStyle::Bold)
+            .with_children(__ftml_inline_nodes!($($inner)*))
+    }};
+    (i { $($inner:tt)* }) => {{
+        $crate::Span::new_styled($crate::InlineStyle::Italic)
+            .with_children(__ftml_inline_nodes!($($inner)*))
+    }};
+    (u { $($inner:tt)* }) => {{
+        $crate::Span::new_styled($crate::InlineStyle::Underline)
+            .with_children(__ftml_inline_nodes!($($inner)*))
+    }};
+    (del { $($inner:tt)* }) => {{
+        $crate::Span::new_styled($crate::InlineStyle::Strike)
+            .with_children(__ftml_inline_nodes!($($inner)*))
+    }};
+    (mark { $($inner:tt)* }) => {{
+        $crate::Span::new_styled($crate::InlineStyle::Highlight)
+            .with_children(__ftml_inline_nodes!($($inner)*))
+    }};
+    (code { $($inner:tt)* }) => {{
+        $crate::Span::new_styled($crate::InlineStyle::Code)
+            .with_children(__ftml_inline_nodes!($($inner)*))
+    }};
+    ($other:ident { $($inner:tt)* }) => {{
+        compile_error!(concat!("Unknown FTML inline element: ", stringify!($other)));
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_list_entries {
+    () => {
+        ::std::vec::Vec::<::std::vec::Vec<$crate::Paragraph>>::new()
+    };
+    ($($tt:tt)*) => {{
+        let mut __entries: ::std::vec::Vec<::std::vec::Vec<$crate::Paragraph>> =
+            ::std::vec::Vec::new();
+        __ftml_list_entries_inner!(__entries, $($tt)*);
+        __entries
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __ftml_list_entries_inner {
+    ($vec:ident,) => {};
+    ($vec:ident) => {};
+    ($vec:ident, , $($rest:tt)*) => {
+        __ftml_list_entries_inner!($vec, $($rest)*);
+    };
+    ($vec:ident, li { $($inner:tt)* } $($rest:tt)*) => {{
+        $vec.push(__ftml_collect_blocks!($($inner)*));
+        __ftml_list_entries_inner!($vec, $($rest)*);
+    }};
+    ($vec:ident, $other:ident { $($inner:tt)* } $($rest:tt)*) => {{
+        compile_error!(concat!("Expected `li` inside list, found `", stringify!($other), "`"));
+    }};
+    ($vec:ident, $unexpected:tt $($rest:tt)*) => {{
+        compile_error!(concat!(
+            "Unexpected token inside list: ",
+            stringify!($unexpected)
+        ));
+    }};
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! ftml {
+    ($($tt:tt)*) => {{
+        let __paragraphs = __ftml_collect_blocks!($($tt)*);
+        $crate::Document::new().with_paragraphs(__paragraphs)
+    }};
+}

--- a/tests/ftml_macro.rs
+++ b/tests/ftml_macro.rs
@@ -1,0 +1,85 @@
+use tdoc::ftml;
+use tdoc::test_helpers::{
+    b__, code__, doc as doc_, h1_, i__, li_, mark__, ol_, p_, p__, quote_, s__, span, u__, ul_,
+};
+
+#[test]
+fn builds_document_trees() {
+    let doc = ftml! {
+        h1 { "Hello World!" }
+        ul {
+            li {
+                p { "This is a text paragraph inside a list item" }
+                quote { p { "And this is a quoted paragraph in the same item" } }
+            }
+        }
+        p { "Inline styles work " b { "just as well" } "." }
+    };
+
+    let expected = doc_(vec![
+        h1_("Hello World!"),
+        ul_(vec![li_(vec![
+            p__("This is a text paragraph inside a list item"),
+            quote_(vec![p__("And this is a quoted paragraph in the same item")]),
+        ])]),
+        p_(vec![
+            span("Inline styles work "),
+            b__("just as well"),
+            span("."),
+        ]),
+    ]);
+
+    assert_eq!(doc, expected);
+}
+
+#[test]
+fn supports_inline_styles_and_lists() {
+    let doc = ftml! {
+        p {
+            "Plain "
+            b { "bold" }
+            " and "
+            i { "italic" }
+            " plus "
+            u { "underline" }
+            " and "
+            del { "deleted" }
+            " with "
+            mark { "highlight" }
+            " and "
+            code { "inline code" }
+        }
+        ol {
+            li { p { "First" } }
+            li {
+                p { "Second" }
+                ul {
+                    li { p { "Nested" } }
+                }
+            }
+        }
+    };
+
+    let expected = doc_(vec![
+        p_(vec![
+            span("Plain "),
+            b__("bold"),
+            span(" and "),
+            i__("italic"),
+            span(" plus "),
+            u__("underline"),
+            span(" and "),
+            s__("deleted"),
+            span(" with "),
+            mark__("highlight"),
+            span(" and "),
+            code__("inline code"),
+        ]),
+        ol_(vec![
+            li_(vec![p__("First")]),
+            li_(vec![p__("Second"), ul_(vec![li_(vec![p__("Nested")])])]),
+        ]),
+    ]);
+
+    assert_eq!(doc, expected);
+}


### PR DESCRIPTION
This PR adds a macro, `fmtl!`, which can be used to programmatically construct FTML Document structs easily:

```rust
let doc = ftml! {
    h1 { "Hello World!" }
    ul {
        li {
            p { "This is a text paragraph inside a list item" }
            quote { p { "And this is a quoted paragraph in the same item" } }
        }
    }
    p { "Inline styles work " b { "just as well" } "." }
};
```

Ticket: #3 