### PR TITLE
HTTP: Adopt the final response's URL after redirects for link resolution

### DIFF
--- a/src/bin/tdoc.rs
+++ b/src/bin/tdoc.rs
@@ -128,7 +128,6 @@ fn create_reader(
         Some(value) => {
             if let Ok(url) = Url::parse(value) {
                 if url.scheme() == "http" || url.scheme() == "https" {
-                    let origin = ContentOrigin::Url(url.clone());
                     let client = Client::builder()
                         .timeout(Duration::from_secs(10))
                         .build()
@@ -145,7 +144,9 @@ fn create_reader(
                         )
                         .send()
                         .map_err(|err| format!("Unable to fetch {value}: {err}"))?;
-                    let extension = Path::new(url.path())
+                    let final_url = response.url().clone();
+                    let origin = ContentOrigin::Url(final_url.clone());
+                    let extension = Path::new(final_url.path())
                         .extension()
                         .and_then(|ext| ext.to_str());
                     let format = override_format
@@ -154,7 +155,7 @@ fn create_reader(
                     return Ok(InputSource {
                         format,
                         reader: Box::new(response),
-                        display_name: value.to_string(),
+                        display_name: final_url.to_string(),
                         origin,
                     });
                 }


### PR DESCRIPTION
This PR updates the HTTP client, so we adopt the final `response.url()` after redirects for link resolution, format detection, and display name. Link navigation now bases subsequent targets on the post-redirect location.

This should fix the issue of opening a URL like `https://example.com/bla` which immediately get's redirected to `https://example.com/bla/` and then relative links would not work anymore.