### PR TITLE
Markdown: Fix writing code blocks and spans

### DIFF
--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1236,7 +1236,6 @@ fn write_code_block<W: Write>(
     }
 
     writeln!(writer, "{}```", continuation_prefix)?;
-    writeln!(writer)?;
     Ok(())
 }
 
@@ -1795,7 +1794,12 @@ fn write_code_span<W: Write>(
 
     let delimiter_len = longest_backtick_sequence(&content) + 1;
     let delimiter = "`".repeat(delimiter_len.max(1));
-    let needs_padding = content.starts_with(' ') || content.ends_with(' ');
+    // CommonMark strips a single leading/trailing space from a code span, which
+    // lets the content itself begin or end with a backtick without merging into
+    // the delimiter. Pad whenever the content starts or ends with a space (so
+    // that space is preserved) or a backtick (so `` `code` `` is not written as
+    // ```` ```code``` ````, which would re-parse to `code`).
+    let needs_padding = content.starts_with([' ', '`']) || content.ends_with([' ', '`']);
 
     state.ensure_prefix(writer)?;
     writer.write_all(delimiter.as_bytes())?;
@@ -2399,5 +2403,46 @@ mod tests {
         } else {
             panic!("Expected code block");
         }
+    }
+
+    #[test]
+    fn test_code_block_writes_single_trailing_newline() {
+        // A code block is a paragraph like any other and must end with exactly
+        // one newline; the inter-paragraph blank line is added by the caller.
+        let mut output = Vec::new();
+        write(&mut output, &doc(vec![code_block__("code")])).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), "```\ncode\n```\n");
+    }
+
+    #[test]
+    fn test_code_block_between_paragraphs_round_trips() {
+        let input = "before\n\n```\ncode\n```\n\nafter\n";
+        let parsed = parse(Cursor::new(input)).unwrap();
+        let mut output = Vec::new();
+        write(&mut output, &parsed).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), input);
+    }
+
+    #[test]
+    fn test_code_span_containing_backticks_round_trips() {
+        // A code span whose content begins or ends with a backtick must be
+        // space-padded so it does not merge with its delimiter: `` `code` ``
+        // (content "`code`") must not degrade to ```code``` (content "code").
+        let input = "Type `` `code` `` here\n";
+        let parsed = parse(Cursor::new(input)).unwrap();
+        let mut output = Vec::new();
+        write(&mut output, &parsed).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), input);
+    }
+
+    #[test]
+    fn test_code_span_with_backtick_content_is_preserved() {
+        // Guards against silent content corruption: the code-span content must
+        // survive a write/re-parse cycle unchanged.
+        let parsed = parse(Cursor::new("`` `code` ``")).unwrap();
+        let mut output = Vec::new();
+        write(&mut output, &parsed).unwrap();
+        let reparsed = parse(Cursor::new(String::from_utf8(output).unwrap())).unwrap();
+        assert_eq!(reparsed, parsed);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -210,10 +210,9 @@ fn test_markdown_code_block_roundtrip() {
     let mut output = Vec::new();
     markdown::write(&mut output, &doc).unwrap();
     let markdown_out = String::from_utf8(output).unwrap();
-    assert_eq!(
-        markdown_out,
-        "```\nfn main() {}\nprintln!(\"hi\");\n```\n\n"
-    );
+    // A code block ends with a single newline like any other paragraph; the
+    // input round-trips exactly.
+    assert_eq!(markdown_out, "```\nfn main() {}\nprintln!(\"hi\");\n```\n");
 }
 
 #[test]
@@ -225,11 +224,9 @@ fn test_markdown_code_block_trims_leading_newline() {
     markdown::write(&mut output, &doc).unwrap();
     let markdown_out = String::from_utf8(output).unwrap();
 
-    // Trailing newline is stripped, but writer adds one before closing fence
-    assert_eq!(
-        markdown_out,
-        "```\nfn main() {}\nprintln!(\"hi\");\n```\n\n"
-    );
+    // Leading/trailing content newlines are stripped; the block ends with a
+    // single trailing newline (no extra blank line).
+    assert_eq!(markdown_out, "```\nfn main() {}\nprintln!(\"hi\");\n```\n");
 }
 
 #[test]
@@ -241,11 +238,9 @@ fn test_markdown_code_block_preserves_blank_first_line() {
     markdown::write(&mut output, &doc).unwrap();
     let markdown_out = String::from_utf8(output).unwrap();
 
-    // Trailing newline is stripped, but writer adds one before closing fence
-    assert_eq!(
-        markdown_out,
-        "```\n\nfn main() {}\nprintln!(\"hi\");\n```\n\n"
-    );
+    // A blank first line inside the block is preserved; the block still ends
+    // with a single trailing newline (no extra blank line).
+    assert_eq!(markdown_out, "```\n\nfn main() {}\nprintln!(\"hi\");\n```\n");
 }
 
 #[test]

--- a/tests/snapshots/html/convert-markdown/freebsd-15-relnotes.snap.md
+++ b/tests/snapshots/html/convert-markdown/freebsd-15-relnotes.snap.md
@@ -158,7 +158,6 @@ any of head, stable/15, or releng/15.0 branches after 2025-11-27 22:00 UTC.
 # cp -R /usr/src/share/keys/pkgbase-15 /usr/share/keys/pkgbase-15
 ```
 
-
 Users who do not have up to date sources installed may use a less secure, but
 simpler approach, validating the checksums after installation. As these are
 architecture-independent files, the checksums will match on all platforms.
@@ -172,7 +171,6 @@ ab261a3b84ffc11654ac0bafbb7d6b3f1b6afc30bfabab3bcff64259678eac26 /etc/pkg/FreeBS
 529c79e85a6ca152faa9d57ead85fe0111ffada8d0a0fa2f11fc510999fa50df /usr/share/keys/pkgbase-15/trusted/awskms-15
 c368ec8d05654bdaad34742c1d75b9b150bfc3892838cef32f6e5b036b0c0605 /usr/share/keys/pkgbase-15/trusted/backup-signing-15
 ```
-
 
 Upgrading FreeBSD should only be attempted after backing up _all_ data and
 configuration files.

--- a/tests/snapshots/snapshot_tests__test_code_block.snap.md
+++ b/tests/snapshots/snapshot_tests__test_code_block.snap.md
@@ -16,5 +16,4 @@ if width < 60 {
 }
 ```
 
-
 The end.


### PR DESCRIPTION
Bug 1: code blocks emitted a trailing blank line. `write_code_block` had a stray writeln!(writer) after the closing fence, so a code block ended with two newlines while every other paragraph ends with one (inter-paragraph spacing is added by the caller).

Bug 2: code spans corrupted content that touched a backtick. `write_code_span` only space-padded when content started/ended with a space.