### PR TITLE
Add support for definition lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Whatever format you read, tdoc parses it into the same document tree, a hierarch
 - **Blockquotes** (`<blockquote>`)
 - **Tables** (`<table>`)
 - **Horizontal rules** (HTML `<hr>`, Markdown `---`)
+- **Definition lists** (HTML `<dl>`, Markdown `Term`/`: definition`)
 
 ### Horizontal Rules
 
@@ -120,6 +121,37 @@ run of Unicode line characters around a spaced bullet (`───── • ─�
 blank line of breathing room above and below. Gemtext likewise has no
 thematic-break construct, so on Gemini export a rule degrades to a plain-text
 `---` divider.
+
+### Definition Lists
+
+A definition list pairs one or more terms with a definition. It is parsed
+from `<dl>`/`<dt>`/`<dd>` in HTML and from the PHP Markdown Extra syntax in
+Markdown, where a term sits on its own line and each description that follows is
+introduced by a `: ` marker:
+
+```markdown
+Coffee
+: A hot black beverage
+
+Milk
+: A cold white beverage
+: Best served chilled
+```
+
+Each item carries a single definition, held as a list of block paragraphs;
+consecutive terms share the definition that follows them. When a source lists
+several definitions for the same term (multiple `<dd>`s, or multiple `: ` lines),
+they are folded into that one definition as separate paragraphs. Like tables and
+horizontal rules, definition lists are a tdoc extension rather than part of
+strict FTML: build one with the `dl { item { term { … } def { … } } }` block in
+the [`doc!`](https://docs.rs/tdoc/latest/tdoc/macro.doc.html) macro (the strict
+[`ftml!`](https://docs.rs/tdoc/latest/tdoc/macro.ftml.html) macro rejects it).
+Because **FTML has no definition-list element**, exporting to FTML flattens each
+term and definition paragraph into its own `<p>` (the same way tables are
+flattened), preserving the text. **Gemtext** likewise has no such construct, so
+on Gemini export the list degrades to plain text with each term on its own line
+and its definition indented beneath it. In the terminal, terms are shown in bold
+at the left margin with their definition indented below.
 
 ### Checklists
 
@@ -238,6 +270,12 @@ fn main() -> tdoc::Result<()> {
         table {
             row { th { "Feature" } th { "Status" } }
             row { td { "Tables" } td { "Supported" } }
+        }
+        dl {
+            item {
+                term { "tdoc" }
+                def { p { "A text document toolkit" } }
+            }
         }
     };
 

--- a/README.md
+++ b/README.md
@@ -141,17 +141,41 @@ Milk
 Each item carries a single definition, held as a list of block paragraphs;
 consecutive terms share the definition that follows them. When a source lists
 several definitions for the same term (multiple `<dd>`s, or multiple `: ` lines),
-they are folded into that one definition as separate paragraphs. Like tables and
-horizontal rules, definition lists are a tdoc extension rather than part of
-strict FTML: build one with the `dl { item { term { … } def { … } } }` block in
-the [`doc!`](https://docs.rs/tdoc/latest/tdoc/macro.doc.html) macro (the strict
+they are folded into that one definition as separate paragraphs. Writing the
+document back out therefore emits one description per item, however many blocks
+it holds: a single `<dd>` in HTML, and in Markdown a single `: ` marker on the
+first block with the rest indented beneath it. So the example above round-trips
+as:
+
+```markdown
+Milk
+: A cold white beverage
+  
+  Best served chilled
+```
+
+Three caveats on Markdown specifically. The `~` marker some dialects accept is
+**not** supported, because pulldown-cmark (tdoc's Markdown engine) uses `~` for
+strikethrough. The Markdown syntax has no way to give several terms one shared
+definition, so an item with multiple terms — readily expressed in HTML as
+consecutive `<dt>`s — comes back as a single term after a Markdown round-trip.
+And a description with no term at all, which HTML can express as a stray `<dd>`,
+has no Markdown spelling either: because a `:` line binds to the block above it,
+tdoc writes an HTML comment ahead of such a list to stop it swallowing the
+preceding paragraph, and the list degrades to a paragraph when re-imported.
+
+Like tables and horizontal rules, definition lists are a tdoc extension rather
+than part of strict FTML: build one with the
+`dl { item { term { … } def { … } } }` block in the
+[`doc!`](https://docs.rs/tdoc/latest/tdoc/macro.doc.html) macro (the strict
 [`ftml!`](https://docs.rs/tdoc/latest/tdoc/macro.ftml.html) macro rejects it).
 Because **FTML has no definition-list element**, exporting to FTML flattens each
 term and definition paragraph into its own `<p>` (the same way tables are
 flattened), preserving the text. **Gemtext** likewise has no such construct, so
 on Gemini export the list degrades to plain text with each term on its own line
-and its definition indented beneath it. In the terminal, terms are shown in bold
-at the left margin with their definition indented below.
+and its definition indented beneath it; block content inside a definition is
+flattened into indented lines rather than dropped. In the terminal, terms are
+shown in bold at the left margin with their definition indented below.
 
 ### Checklists
 

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1,6 +1,8 @@
 //! Render documents to formatted plain text suitable for terminals or logs.
 
-use crate::{ChecklistItem, Document, InlineStyle, Paragraph, ParagraphType, Span, TableRow};
+use crate::{
+    ChecklistItem, DefinitionItem, Document, InlineStyle, Paragraph, ParagraphType, Span, TableRow,
+};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
@@ -519,6 +521,57 @@ impl<W: Write> Formatter<W> {
             ParagraphType::HorizontalRule => {
                 self.write_horizontal_rule(prefix)?;
             }
+            ParagraphType::DefinitionList => {
+                self.write_definition_list(
+                    paragraph.definition_items(),
+                    prefix,
+                    continuation_prefix,
+                    blank_line_prefix,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Renders a definition list: each term sits at the left margin (emphasized
+    /// in bold when the style emits ANSI) with its definition indented beneath
+    /// it, and a blank line separates groups.
+    fn write_definition_list(
+        &mut self,
+        items: &[DefinitionItem],
+        prefix: &str,
+        continuation_prefix: &str,
+        blank_line_prefix: &str,
+    ) -> std::io::Result<()> {
+        let definition_indent = format!("{}    ", continuation_prefix);
+
+        for (item_idx, item) in items.iter().enumerate() {
+            if item_idx > 0 {
+                self.write_blank_lines_with_prefix(blank_line_prefix, 1)?;
+            }
+
+            for (term_idx, term) in item.terms.iter().enumerate() {
+                let term_prefix = if item_idx == 0 && term_idx == 0 {
+                    prefix
+                } else {
+                    continuation_prefix
+                };
+                // Emphasize the term in bold. In ASCII the bold style carries no
+                // escapes, so the term renders as plain text.
+                let bold_term =
+                    vec![Span::new_styled(InlineStyle::Bold).with_children(term.clone())];
+                self.write_text_paragraph(&bold_term, term_prefix, continuation_prefix)?;
+            }
+
+            // Render the whole definition as one block so its paragraphs are
+            // separated by the usual blank line (the first sits directly under
+            // the term, with no blank line between term and definition).
+            self.write_paragraphs(
+                &item.definition,
+                &definition_indent,
+                &definition_indent,
+                &definition_indent,
+            )?;
         }
         Ok(())
     }
@@ -2433,6 +2486,47 @@ mod tests {
         assert!(
             result.contains("\x1b[2m───── • ─────\x1b[22m"),
             "expected a dim rule, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_definition_list_ascii_indents_descriptions() {
+        let document = doc(vec![dl_(vec![
+            di_(
+                vec![spans("Apple")],
+                vec![p__("Pomaceous fruit"), p__("An American company")],
+            ),
+            di_(vec![spans("Orange")], vec![p__("Citrus fruit")]),
+        ])]);
+        let result = render_doc(document, FormattingStyle::ascii());
+
+        // Terms sit at the margin (bold carries no ASCII escapes, so they render
+        // plain); the definition is indented beneath, with the usual blank line
+        // between its paragraphs (carrying the indent, as list items do), and a
+        // blank line separates the two groups.
+        assert_eq!(
+            result,
+            "Apple\n    Pomaceous fruit\n    \n    An American company\n\n\
+             Orange\n    Citrus fruit\n"
+        );
+    }
+
+    #[test]
+    fn test_definition_list_ansi_term_is_bold() {
+        let document = doc(vec![dl_(vec![di_(
+            vec![spans("Apple")],
+            vec![p__("Pomaceous fruit")],
+        )])]);
+        let result = render_doc(document, FormattingStyle::ansi());
+
+        // The term is wrapped in the bold on/off SGR pair; the definition is not.
+        assert!(
+            result.contains("\x1b[1mApple\x1b[22m"),
+            "expected a bold term, got: {result:?}"
+        );
+        assert!(
+            !result.contains("\x1b[1mPomaceous"),
+            "definition text must not be bold, got: {result:?}"
         );
     }
 

--- a/src/ftml/parser.rs
+++ b/src/ftml/parser.rs
@@ -1416,6 +1416,18 @@ fn normalize_paragraph_spaces(paragraph: &mut Paragraph) {
                 }
             }
         }
+        Paragraph::DefinitionList { items } => {
+            // FTML has no definition-list syntax, so the parser never produces
+            // one; a document built by hand still normalizes cleanly, though.
+            for item in items {
+                for term in &mut item.terms {
+                    normalize_spans_spaces(term);
+                }
+                for paragraph in &mut item.definition {
+                    normalize_paragraph_spaces(paragraph);
+                }
+            }
+        }
         Paragraph::Checklist { .. }
         | Paragraph::Text { .. }
         | Paragraph::Header1 { .. }
@@ -1683,6 +1695,25 @@ mod tests {
                 "input: {input:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_definition_list_is_not_part_of_ftml() {
+        // FTML has no definition-list construct. `<dl>`/`<dt>`/`<dd>` are not
+        // recognized wrapper elements, so an empty list is simply ignored,
+        // leaving the surrounding blocks untouched.
+        let doc = parse(Cursor::new("<p>A</p><dl></dl><p>B</p>")).unwrap();
+        assert_eq!(
+            doc.paragraphs
+                .iter()
+                .map(|p| p.paragraph_type())
+                .collect::<Vec<_>>(),
+            vec![ParagraphType::Text, ParagraphType::Text],
+        );
+
+        // As with any unrecognized block wrapper, stray text inside one is
+        // rejected rather than silently absorbed.
+        assert!(parse(Cursor::new("<dl><dt>Term</dt><dd>Def</dd></dl>")).is_err());
     }
 
     #[test]

--- a/src/ftml/writer.rs
+++ b/src/ftml/writer.rs
@@ -3,7 +3,8 @@
 //! For HTML output that preserves table structure, see [`crate::html::write`].
 
 use crate::{
-    ChecklistItem, Document, InlineStyle, Paragraph, ParagraphType, Span, TableCell, TableRow,
+    ChecklistItem, DefinitionItem, Document, InlineStyle, Paragraph, ParagraphType, Span,
+    TableCell, TableRow,
 };
 use regex::Regex;
 use std::collections::HashMap;
@@ -133,6 +134,14 @@ impl Writer {
 
         if paragraph_type == ParagraphType::Table {
             return self.write_table_paragraph(writer, paragraph.rows(), level);
+        }
+
+        if paragraph_type == ParagraphType::DefinitionList {
+            return self.write_definition_list_paragraph(
+                writer,
+                paragraph.definition_items(),
+                level,
+            );
         }
 
         if paragraph_type == ParagraphType::HorizontalRule {
@@ -351,6 +360,126 @@ impl Writer {
 
         self.write_indent(writer, level)?;
         writeln!(writer, "</{}>", tag)
+    }
+
+    fn write_definition_list_paragraph<W: Write>(
+        &self,
+        writer: &mut W,
+        items: &[DefinitionItem],
+        level: usize,
+    ) -> io::Result<()> {
+        if self.emit_tables {
+            self.write_html_definition_list(writer, items, level)
+        } else {
+            self.write_flattened_definition_list(writer, items, level)
+        }
+    }
+
+    fn write_html_definition_list<W: Write>(
+        &self,
+        writer: &mut W,
+        items: &[DefinitionItem],
+        level: usize,
+    ) -> io::Result<()> {
+        self.write_indent(writer, level)?;
+        writeln!(writer, "<dl>")?;
+
+        for item in items {
+            for term in &item.terms {
+                self.write_leaf_paragraph(writer, term, "dt", level + 1)?;
+            }
+            // Each paragraph of the single definition becomes its own `<dd>`, so
+            // a term with several definitions round-trips through HTML.
+            for paragraph in &item.definition {
+                self.write_definition_description(
+                    writer,
+                    std::slice::from_ref(paragraph),
+                    level + 1,
+                )?;
+            }
+        }
+
+        self.write_indent(writer, level)?;
+        writeln!(writer, "</dl>")
+    }
+
+    fn write_definition_description<W: Write>(
+        &self,
+        writer: &mut W,
+        paragraphs: &[Paragraph],
+        level: usize,
+    ) -> io::Result<()> {
+        match paragraphs {
+            // An empty description still needs an element to attach to.
+            [] => {
+                self.write_indent(writer, level)?;
+                writeln!(writer, "<dd></dd>")
+            }
+            // A lone text paragraph collapses to a compact `<dd>text</dd>` line,
+            // mirroring how simple list items and cells are rendered inline.
+            [single] if single.paragraph_type() == ParagraphType::Text => {
+                self.write_leaf_paragraph(writer, single.content(), "dd", level)
+            }
+            // Anything richer (multiple paragraphs, lists, quotes) keeps the
+            // `<dd>` wrapper on its own lines with the block content nested.
+            _ => {
+                self.write_indent(writer, level)?;
+                writeln!(writer, "<dd>")?;
+                let mut first = true;
+                for child in paragraphs {
+                    if self.should_skip(child) {
+                        continue;
+                    }
+                    if first {
+                        first = false;
+                    } else {
+                        writeln!(writer)?;
+                    }
+                    self.write_paragraph(writer, child, level + 1)?;
+                }
+                self.write_indent(writer, level)?;
+                writeln!(writer, "</dd>")
+            }
+        }
+    }
+
+    /// Strict FTML has no definition-list syntax, so a `<dl>` that arrived via
+    /// conversion is flattened: each term and each definition paragraph becomes
+    /// its own `<p>`, preserving the text the way tables are flattened to
+    /// paragraphs.
+    fn write_flattened_definition_list<W: Write>(
+        &self,
+        writer: &mut W,
+        items: &[DefinitionItem],
+        level: usize,
+    ) -> io::Result<()> {
+        let mut first = true;
+        let mut separate = |writer: &mut W| -> io::Result<()> {
+            if first {
+                first = false;
+            } else {
+                writeln!(writer)?;
+            }
+            Ok(())
+        };
+
+        for item in items {
+            for term in &item.terms {
+                if term.iter().all(|span| span.is_content_empty()) {
+                    continue;
+                }
+                separate(writer)?;
+                self.write_leaf_paragraph(writer, term, "p", level)?;
+            }
+            for paragraph in &item.definition {
+                if self.should_skip(paragraph) || is_empty_leaf(paragraph) {
+                    continue;
+                }
+                separate(writer)?;
+                self.write_paragraph(writer, paragraph, level)?;
+            }
+        }
+        Ok(())
     }
 
     fn write_checklist_item<W: Write>(
@@ -748,6 +877,17 @@ impl Writer {
     }
 }
 
+/// Whether a paragraph is a leaf that carries no visible content and can be
+/// dropped when flattening (e.g. an empty description paragraph).
+fn is_empty_leaf(paragraph: &Paragraph) -> bool {
+    paragraph.is_leaf()
+        && paragraph.paragraph_type() != ParagraphType::HorizontalRule
+        && paragraph
+            .content()
+            .iter()
+            .all(|span| span.is_content_empty())
+}
+
 /// Convenience helper that writes using a fresh [`Writer`] with default settings.
 pub fn write<W: Write>(writer: &mut W, document: &Document) -> io::Result<()> {
     let w = Writer::new();
@@ -837,6 +977,35 @@ mod tests {
         // The HTML writer, by contrast, keeps it as a `<hr />` void element.
         let html = Writer::new_html().write_to_string(&doc).unwrap();
         assert_eq!(html, "<p>A</p>\n\n<hr />\n\n<p>B</p>\n");
+    }
+
+    #[test]
+    fn test_definition_list_flattened_by_ftml_writer() {
+        use crate::DefinitionItem;
+
+        let dl =
+            Paragraph::new_definition_list().with_definition_items(vec![DefinitionItem::new()
+                .with_terms(vec![vec![Span::new_text("Apple")]])
+                .with_definition(vec![
+                    Paragraph::new_text().with_content(vec![Span::new_text("Pomaceous fruit")]),
+                    Paragraph::new_text().with_content(vec![Span::new_text("A company")]),
+                ])]);
+        let doc = Document::new().with_paragraphs(vec![dl]);
+
+        // Strict FTML has no `<dl>`; terms and definitions flatten to `<p>`s,
+        // just as tables flatten to paragraphs.
+        let ftml = Writer::new().write_to_string(&doc).unwrap();
+        assert_eq!(
+            ftml,
+            "<p>Apple</p>\n\n<p>Pomaceous fruit</p>\n\n<p>A company</p>\n"
+        );
+
+        // The HTML writer keeps the real `<dl>` structure.
+        let html = Writer::new_html().write_to_string(&doc).unwrap();
+        assert_eq!(
+            html,
+            "<dl>\n  <dt>Apple</dt>\n  <dd>Pomaceous fruit</dd>\n  <dd>A company</dd>\n</dl>\n"
+        );
     }
 
     #[test]

--- a/src/ftml/writer.rs
+++ b/src/ftml/writer.rs
@@ -388,15 +388,9 @@ impl Writer {
             for term in &item.terms {
                 self.write_leaf_paragraph(writer, term, "dt", level + 1)?;
             }
-            // Each paragraph of the single definition becomes its own `<dd>`, so
-            // a term with several definitions round-trips through HTML.
-            for paragraph in &item.definition {
-                self.write_definition_description(
-                    writer,
-                    std::slice::from_ref(paragraph),
-                    level + 1,
-                )?;
-            }
+            // The item carries one definition, so it emits one `<dd>` however
+            // many blocks that definition holds.
+            self.write_definition_description(writer, &item.definition, level + 1)?;
         }
 
         self.write_indent(writer, level)?;
@@ -1000,11 +994,13 @@ mod tests {
             "<p>Apple</p>\n\n<p>Pomaceous fruit</p>\n\n<p>A company</p>\n"
         );
 
-        // The HTML writer keeps the real `<dl>` structure.
+        // The HTML writer keeps the real `<dl>` structure, with the item's one
+        // definition emitted as a single `<dd>` holding both blocks.
         let html = Writer::new_html().write_to_string(&doc).unwrap();
         assert_eq!(
             html,
-            "<dl>\n  <dt>Apple</dt>\n  <dd>Pomaceous fruit</dd>\n  <dd>A company</dd>\n</dl>\n"
+            "<dl>\n  <dt>Apple</dt>\n  <dd>\n    <p>Pomaceous fruit</p>\n\n    \
+             <p>A company</p>\n  </dd>\n</dl>\n"
         );
     }
 

--- a/src/gemini/mod.rs
+++ b/src/gemini/mod.rs
@@ -330,6 +330,22 @@ fn write_paragraph<W: Write>(writer: &mut W, paragraph: &Paragraph) -> std::io::
             // divider line so a human reader still sees the separation.
             writeln!(writer, "---")?;
         }
+        Paragraph::DefinitionList { items } => {
+            // Gemtext has no definition-list syntax. Degrade to plain text: each
+            // term on its own line, with its descriptions indented below so a
+            // human reader can still tell them apart.
+            for item in items {
+                for term in &item.terms {
+                    write_spans_plain(writer, term)?;
+                    writeln!(writer)?;
+                }
+                for paragraph in &item.definition {
+                    write!(writer, "  ")?;
+                    write_paragraph_inline(writer, paragraph)?;
+                    writeln!(writer)?;
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/src/gemini/mod.rs
+++ b/src/gemini/mod.rs
@@ -332,7 +332,7 @@ fn write_paragraph<W: Write>(writer: &mut W, paragraph: &Paragraph) -> std::io::
         }
         Paragraph::DefinitionList { items } => {
             // Gemtext has no definition-list syntax. Degrade to plain text: each
-            // term on its own line, with its descriptions indented below so a
+            // term on its own line, with its definition indented below so a
             // human reader can still tell them apart.
             for item in items {
                 for term in &item.terms {
@@ -340,9 +340,7 @@ fn write_paragraph<W: Write>(writer: &mut W, paragraph: &Paragraph) -> std::io::
                     writeln!(writer)?;
                 }
                 for paragraph in &item.definition {
-                    write!(writer, "  ")?;
-                    write_paragraph_inline(writer, paragraph)?;
-                    writeln!(writer)?;
+                    write_indented_plain(writer, paragraph, "  ")?;
                 }
             }
         }
@@ -410,6 +408,113 @@ fn write_paragraph_inline<W: Write>(writer: &mut W, paragraph: &Paragraph) -> st
         _ => {}
     }
     Ok(())
+}
+
+/// Flattens a block paragraph into indented plain-text lines.
+///
+/// Gemtext cannot nest blocks, so a definition holding a list, quote, table or
+/// nested definition list has nowhere structural to go. Rather than dropping
+/// that content, every block type is reduced to the lines a human reader still
+/// needs, carrying `indent` so the nesting remains legible.
+fn write_indented_plain<W: Write>(
+    writer: &mut W,
+    paragraph: &Paragraph,
+    indent: &str,
+) -> std::io::Result<()> {
+    match paragraph {
+        Paragraph::Text { content }
+        | Paragraph::Header1 { content }
+        | Paragraph::Header2 { content }
+        | Paragraph::Header3 { content }
+        | Paragraph::CodeBlock { content } => {
+            write_indented_lines(writer, indent, &spans_to_plain(content))?;
+        }
+        Paragraph::Quote { children } => {
+            for child in children {
+                write_indented_plain(writer, child, indent)?;
+            }
+        }
+        Paragraph::UnorderedList { entries } | Paragraph::OrderedList { entries } => {
+            let marker = format!("{}* ", indent);
+            let nested = format!("{}  ", indent);
+            for entry in entries {
+                for (idx, child) in entry.iter().enumerate() {
+                    let child_indent = if idx == 0 { &marker } else { &nested };
+                    write_indented_plain(writer, child, child_indent)?;
+                }
+            }
+        }
+        Paragraph::Checklist { items } => {
+            for item in items {
+                let marker = if item.checked { "[x]" } else { "[ ]" };
+                writeln!(
+                    writer,
+                    "{}* {} {}",
+                    indent,
+                    marker,
+                    spans_to_plain(&item.content)
+                )?;
+                for child in &item.children {
+                    let marker = if child.checked { "[x]" } else { "[ ]" };
+                    writeln!(
+                        writer,
+                        "{}  * {} {}",
+                        indent,
+                        marker,
+                        spans_to_plain(&child.content)
+                    )?;
+                }
+            }
+        }
+        Paragraph::Table { rows } => {
+            for row in rows {
+                for cell in &row.cells {
+                    if cell.content.iter().all(|span| span.is_content_empty()) {
+                        continue;
+                    }
+                    write_indented_lines(writer, indent, &spans_to_plain(&cell.content))?;
+                }
+            }
+        }
+        Paragraph::HorizontalRule => {
+            writeln!(writer, "{}---", indent)?;
+        }
+        Paragraph::DefinitionList { items } => {
+            let nested = format!("{}  ", indent);
+            for item in items {
+                for term in &item.terms {
+                    write_indented_lines(writer, indent, &spans_to_plain(term))?;
+                }
+                for paragraph in &item.definition {
+                    write_indented_plain(writer, paragraph, &nested)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Writes `text` line by line with `indent` in front of every non-empty line.
+fn write_indented_lines<W: Write>(writer: &mut W, indent: &str, text: &str) -> std::io::Result<()> {
+    if text.is_empty() {
+        return Ok(());
+    }
+    for line in text.split('\n') {
+        if line.is_empty() {
+            writeln!(writer)?;
+        } else {
+            writeln!(writer, "{}{}", indent, line)?;
+        }
+    }
+    Ok(())
+}
+
+/// Renders inline spans to a plain string, dropping all styling.
+fn spans_to_plain(spans: &[Span]) -> String {
+    let mut buffer = Vec::new();
+    // Writing into a `Vec` cannot fail, so the error case is unreachable.
+    let _ = write_spans_plain(&mut buffer, spans);
+    String::from_utf8_lossy(&buffer).into_owned()
 }
 
 fn write_spans_plain<W: Write>(writer: &mut W, spans: &[Span]) -> std::io::Result<()> {
@@ -635,5 +740,45 @@ mod tests {
             result,
             "```\nfn main() {\n    println!(\"Hello\");\n}\n```\n"
         );
+    }
+
+    #[test]
+    fn test_write_definition_list() {
+        let mut output = Vec::new();
+        let doc = doc(vec![dl_(vec![
+            di_(
+                vec![spans("Apple")],
+                vec![p__("Pomaceous fruit"), p__("An American company")],
+            ),
+            di_(
+                vec![spans("Beta"), spans("Gamma")],
+                vec![p__("Two greek letters")],
+            ),
+        ])]);
+        write(&mut output, &doc).unwrap();
+        let result = String::from_utf8(output).unwrap();
+        assert_eq!(
+            result,
+            "Apple\n  Pomaceous fruit\n  An American company\n\
+             Beta\nGamma\n  Two greek letters\n"
+        );
+    }
+
+    #[test]
+    fn test_write_definition_list_keeps_block_content() {
+        // Gemtext cannot nest blocks, but a definition holding a list, quote or
+        // table must still be flattened into readable lines rather than dropped.
+        let mut output = Vec::new();
+        let doc = doc(vec![dl_(vec![di_(
+            vec![spans("Term")],
+            vec![
+                p__("intro"),
+                ul_(vec![li_(vec![p__("one")]), li_(vec![p__("two")])]),
+                quote_(vec![p__("quoted")]),
+            ],
+        )])]);
+        write(&mut output, &doc).unwrap();
+        let result = String::from_utf8(output).unwrap();
+        assert_eq!(result, "Term\n  intro\n  * one\n  * two\n  quoted\n");
     }
 }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -9,7 +9,8 @@ pub mod gockl;
 
 use crate::ftml::Writer;
 use crate::{
-    ChecklistItem, Document, InlineStyle, Paragraph, ParagraphType, Span, TableCell, TableRow,
+    ChecklistItem, DefinitionItem, Document, InlineStyle, Paragraph, ParagraphType, Span,
+    TableCell, TableRow,
 };
 use gockl::{StartElementToken, Token, Tokenizer, TokenizerError};
 use html_escape::decode_html_entities;
@@ -134,6 +135,19 @@ impl<'a> Parser<'a> {
                     return Ok(());
                 }
 
+                if tag == "dl" {
+                    self.down(ParagraphType::DefinitionList)?;
+                    return Ok(());
+                }
+
+                if tag == "dt" {
+                    return self.read_definition_term();
+                }
+
+                // `<dd>` needs no handler of its own: its block content flows
+                // into the current definition item via `down`, and consecutive
+                // `<dd>`s simply append more paragraphs to the one definition.
+
                 if tag == "li" {
                     let parent = match self.parent() {
                         Some(parent) => parent,
@@ -172,6 +186,17 @@ impl<'a> Parser<'a> {
                     if self.list_item_level > 0 {
                         self.list_item_level -= 1;
                     }
+                    return Ok(());
+                }
+
+                if tag == "dl" {
+                    return self.up(ParagraphType::DefinitionList);
+                }
+
+                // `</dt>` and `</dd>` are consumed while their content is read;
+                // any that reach here (e.g. after a nested block closed the
+                // description) are structurally benign.
+                if tag == "dt" || tag == "dd" {
                     return Ok(());
                 }
 
@@ -845,6 +870,13 @@ impl<'a> Parser<'a> {
                         .expect("list entry present")
                         .push(Rc::clone(&node));
                 }
+                ParagraphType::DefinitionList => {
+                    // Block content inside a `<dd>` attaches to the current
+                    // description slot of the current definition item.
+                    parent
+                        .borrow_mut()
+                        .push_to_current_definition(Rc::clone(&node));
+                }
                 _ => parent.borrow_mut().children.push(Rc::clone(&node)),
             }
         } else {
@@ -896,6 +928,16 @@ impl<'a> Parser<'a> {
                         }
                     }
                 }
+                ParagraphType::DefinitionList => {
+                    let mut parent_mut = parent.borrow_mut();
+                    if let Some(item) = parent_mut.definition_items.last_mut() {
+                        if let Some(last) = item.definition.last() {
+                            if Rc::ptr_eq(last, node) {
+                                item.definition.pop();
+                            }
+                        }
+                    }
+                }
                 _ => {
                     let mut parent_mut = parent.borrow_mut();
                     if let Some(last) = parent_mut.children.last() {
@@ -931,6 +973,34 @@ impl<'a> Parser<'a> {
                 .borrow_mut()
                 .mark_current_list_item_checkbox(checked);
         }
+    }
+
+    /// Reads a `<dt>` term (inline content only) and records it on the nearest
+    /// open definition list. A term that arrives after a description starts a
+    /// new definition group.
+    fn read_definition_term(&mut self) -> Result<(), HtmlError> {
+        let (mut content, extra_token, _closed) = self.read_content(Some("dt"), None)?;
+        trim_trailing_line_breaks(&mut content);
+        trim_trailing_inline_whitespace(&mut content);
+
+        if let Some(dl) = self.nearest_definition_list() {
+            dl.borrow_mut().add_definition_term(content);
+        }
+
+        if let Some(token) = extra_token {
+            self.process_token(token)?;
+        }
+
+        Ok(())
+    }
+
+    /// Finds the innermost open `<dl>` on the breadcrumb stack.
+    fn nearest_definition_list(&self) -> Option<ParagraphNode> {
+        self.breadcrumbs
+            .iter()
+            .rev()
+            .find(|node| node.borrow().paragraph_type == ParagraphType::DefinitionList)
+            .cloned()
     }
 
     fn process_skipped_tags(&mut self, token: &Token) -> bool {
@@ -990,6 +1060,14 @@ enum HtmlError {
     },
 }
 
+/// A partially built definition-list item, mirroring [`DefinitionItem`] but
+/// holding still-mutable [`ParagraphNode`]s for its definition.
+#[derive(Debug, Default)]
+struct DefinitionItemBuilder {
+    terms: Vec<Vec<Span>>,
+    definition: Vec<ParagraphNode>,
+}
+
 #[derive(Debug)]
 struct ParagraphBuilder {
     paragraph_type: ParagraphType,
@@ -998,6 +1076,7 @@ struct ParagraphBuilder {
     entries: Vec<Vec<ParagraphNode>>,
     checklist_states: Vec<Option<bool>>,
     table_rows: Vec<TableRow>,
+    definition_items: Vec<DefinitionItemBuilder>,
 }
 
 impl ParagraphBuilder {
@@ -1009,7 +1088,41 @@ impl ParagraphBuilder {
             entries: Vec::new(),
             checklist_states: Vec::new(),
             table_rows: Vec::new(),
+            definition_items: Vec::new(),
         }
+    }
+
+    /// Records a `<dt>` term. Because consecutive terms share the definition
+    /// that follows them, a term appends to the current item unless that item
+    /// already has definition content, in which case it starts a new one.
+    fn add_definition_term(&mut self, term: Vec<Span>) {
+        let start_new = self
+            .definition_items
+            .last()
+            .map(|item| !item.definition.is_empty())
+            .unwrap_or(true);
+        if start_new {
+            self.definition_items.push(DefinitionItemBuilder::default());
+        }
+        self.definition_items
+            .last_mut()
+            .expect("definition item present")
+            .terms
+            .push(term);
+    }
+
+    /// Attaches a block node to the current definition, materializing an item
+    /// if a `<dd>` appears before any `<dt>`. Each `<dd>` contributes its block
+    /// content as consecutive paragraphs of the single definition.
+    fn push_to_current_definition(&mut self, node: ParagraphNode) {
+        if self.definition_items.is_empty() {
+            self.definition_items.push(DefinitionItemBuilder::default());
+        }
+        self.definition_items
+            .last_mut()
+            .expect("definition item present")
+            .definition
+            .push(node);
     }
 
     fn start_new_list_item(&mut self) {
@@ -1100,8 +1213,41 @@ impl ParagraphBuilder {
                     Paragraph::new_table().with_rows(borrowed.table_rows.clone())
                 }
                 ParagraphType::HorizontalRule => Paragraph::new_horizontal_rule(),
+                ParagraphType::DefinitionList => {
+                    let items = borrowed
+                        .definition_items
+                        .iter()
+                        .filter_map(ParagraphBuilder::to_definition_item)
+                        .collect::<Vec<_>>();
+                    Paragraph::new_definition_list().with_definition_items(items)
+                }
             }
         }
+    }
+
+    /// Converts a [`DefinitionItemBuilder`] into a finished [`DefinitionItem`],
+    /// dropping empty terms and definition paragraphs. Returns `None` when
+    /// nothing meaningful remains.
+    fn to_definition_item(builder: &DefinitionItemBuilder) -> Option<DefinitionItem> {
+        let terms = builder
+            .terms
+            .iter()
+            .filter(|term| term.iter().any(|span| !span.is_content_empty()))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let definition = builder
+            .definition
+            .iter()
+            .map(ParagraphBuilder::to_paragraph)
+            .filter(|child| !is_empty_list(child) && paragraph_has_meaningful_content(child))
+            .collect::<Vec<Paragraph>>();
+
+        if terms.is_empty() && definition.is_empty() {
+            return None;
+        }
+
+        Some(DefinitionItem { terms, definition })
     }
 
     fn entry_to_checklist_item(entry: Vec<Paragraph>, checked: bool) -> Option<ChecklistItem> {
@@ -1154,6 +1300,7 @@ fn is_empty_list(paragraph: &Paragraph) -> bool {
             entries.iter().all(|entry| entry.is_empty())
         }
         Paragraph::Checklist { items } => items.is_empty(),
+        Paragraph::DefinitionList { items } => items.is_empty(),
         _ => false,
     }
 }
@@ -1175,6 +1322,12 @@ fn paragraph_has_meaningful_content(paragraph: &Paragraph) -> bool {
             .any(|row| row.cells.iter().any(|cell| !cell.content.is_empty())),
         // A horizontal rule is itself the content; it is always meaningful.
         Paragraph::HorizontalRule => true,
+        Paragraph::DefinitionList { items } => items.iter().any(|item| {
+            item.terms
+                .iter()
+                .any(|term| term.iter().any(|span| !span.is_content_empty()))
+                || item.definition.iter().any(paragraph_has_meaningful_content)
+        }),
     }
 }
 
@@ -1405,6 +1558,9 @@ fn is_block_level(tag: &str) -> bool {
             | "ol"
             | "li"
             | "hr"
+            | "dl"
+            | "dt"
+            | "dd"
             | "tr"
             | "table"
             | "thead"
@@ -1988,6 +2144,77 @@ mod tests {
         write(&mut output, &doc).unwrap();
         let html = String::from_utf8(output).unwrap();
         assert_eq!(html, "<p>A</p>\n\n<hr />\n\n<p>B</p>\n");
+    }
+
+    #[test]
+    fn parses_definition_list_grouping_terms_and_descriptions() {
+        let input = "<dl><dt>Apple</dt><dd>Pomaceous fruit</dd><dd>A company</dd>\
+                     <dt>Beta</dt><dt>β</dt><dd>Second letter</dd></dl>";
+        let document = parse(Cursor::new(input)).unwrap();
+
+        assert_eq!(document.paragraphs.len(), 1);
+        let items = document.paragraphs[0].definition_items();
+        assert_eq!(items.len(), 2);
+
+        // Apple: one term, two definitions folded into separate paragraphs.
+        assert_eq!(items[0].terms.len(), 1);
+        assert_eq!(items[0].terms[0][0].text, "Apple");
+        assert_eq!(items[0].definition.len(), 2);
+        assert_eq!(items[0].definition[0].content()[0].text, "Pomaceous fruit");
+        assert_eq!(items[0].definition[1].content()[0].text, "A company");
+
+        // A term after a definition opens a new item; two terms share one
+        // definition.
+        assert_eq!(items[1].terms.len(), 2);
+        assert_eq!(items[1].terms[0][0].text, "Beta");
+        assert_eq!(items[1].terms[1][0].text, "β");
+        assert_eq!(items[1].definition.len(), 1);
+        assert_eq!(items[1].definition[0].content()[0].text, "Second letter");
+    }
+
+    #[test]
+    fn parses_definition_description_with_block_content() {
+        let input = "<dl><dt>Term</dt><dd><p>Intro</p><ul><li>one</li><li>two</li></ul></dd></dl>";
+        let document = parse(Cursor::new(input)).unwrap();
+
+        let items = document.paragraphs[0].definition_items();
+        assert_eq!(items.len(), 1);
+        let definition = &items[0].definition;
+        assert_eq!(definition.len(), 2);
+        assert_eq!(definition[0].paragraph_type(), ParagraphType::Text);
+        assert_eq!(definition[1].paragraph_type(), ParagraphType::UnorderedList);
+        assert_eq!(definition[1].entries().len(), 2);
+    }
+
+    #[test]
+    fn writes_definition_list_as_dl_markup() {
+        let doc = Document::new().with_paragraphs(vec![Paragraph::new_definition_list()
+            .with_definition_items(vec![crate::DefinitionItem::new()
+                .with_terms(vec![vec![Span::new_text("Apple")]])
+                .with_definition(vec![
+                    Paragraph::new_text().with_content(vec![Span::new_text("Pomaceous fruit")])
+                ])])]);
+        let mut output = Vec::new();
+        write(&mut output, &doc).unwrap();
+        let html = String::from_utf8(output).unwrap();
+        assert_eq!(
+            html,
+            "<dl>\n  <dt>Apple</dt>\n  <dd>Pomaceous fruit</dd>\n</dl>\n"
+        );
+    }
+
+    #[test]
+    fn writes_multiple_definitions_as_separate_dd_elements() {
+        // A single item with several definition paragraphs emits one `<dd>` per
+        // paragraph, so the list round-trips through HTML.
+        let input = "<dl><dt>Apple</dt><dd>Pomaceous fruit</dd><dd>A company</dd></dl>";
+        let document = parse(Cursor::new(input)).unwrap();
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "<dl>\n  <dt>Apple</dt>\n  <dd>Pomaceous fruit</dd>\n  <dd>A company</dd>\n</dl>\n"
+        );
     }
 
     #[test]

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -1766,9 +1766,17 @@ p { margin-top: 0; margin-bottom: 16px; }
 
 ul, ol { margin-top: 0; margin-bottom: 16px; padding-left: 2em; }
 li + li { margin-top: 0.25em; }
-li > ul, li > ol { margin-top: 0.25em; margin-bottom: 0; }
+li > ul, li > ol, li > dl { margin-top: 0.25em; margin-bottom: 0; }
 li:has(> input[type="checkbox"]) { list-style: none; }
 li > input[type="checkbox"] { margin: 0 0.4em 0 -1.4em; vertical-align: middle; }
+
+dl { margin-top: 0; margin-bottom: 16px; }
+dt { margin-top: 16px; font-weight: 600; }
+dl > dt:first-child { margin-top: 0; }
+dt + dt { margin-top: 0; }
+dd { margin: 0 0 0 2em; }
+dd > :first-child { margin-top: 0; }
+dd > :last-child { margin-bottom: 0; }
 
 blockquote {
   margin: 0 0 16px 0;

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -975,19 +975,51 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Reads a `<dt>` term (inline content only) and records it on the nearest
-    /// open definition list. A term that arrives after a description starts a
-    /// new definition group.
+    /// Reads a `<dt>` term and records it on the nearest open definition list. A
+    /// term that arrives after a description starts a new definition group.
+    ///
+    /// A term holds inline content, but HTML5 permits flow content inside
+    /// `<dt>`, so block wrappers such as `<dt><p>Apple</p></dt>` do occur. There
+    /// is no structure a term can keep them in, so they are flattened: the
+    /// wrapper is dropped and its text joins the term, with a line break between
+    /// what were separate blocks. Only a tag that begins the next part of the
+    /// list — or ends it — closes the term.
     fn read_definition_term(&mut self) -> Result<(), HtmlError> {
-        let (mut content, extra_token, _closed) = self.read_content(Some("dt"), None)?;
-        trim_trailing_line_breaks(&mut content);
-        trim_trailing_inline_whitespace(&mut content);
+        let mut chunks: Vec<Vec<Span>> = Vec::new();
+        let mut pending = None;
+
+        loop {
+            let (chunk, extra_token, _closed) = self.read_content(Some("dt"), None)?;
+            chunks.push(chunk);
+
+            // No token means `</dt>` was consumed or the input ran out.
+            let Some(token) = extra_token else { break };
+
+            if closes_definition_term(&token) {
+                pending = Some(token);
+                break;
+            }
+            // Otherwise the tag is a wrapper to see through; keep reading.
+        }
+
+        let mut content: Vec<Span> = Vec::new();
+        for mut chunk in chunks {
+            trim_trailing_line_breaks(&mut chunk);
+            trim_trailing_inline_whitespace(&mut chunk);
+            if chunk.iter().all(|span| span.is_content_empty()) {
+                continue;
+            }
+            if !content.is_empty() {
+                content.push(Span::new_text("\n"));
+            }
+            content.append(&mut chunk);
+        }
 
         if let Some(dl) = self.nearest_definition_list() {
             dl.borrow_mut().add_definition_term(content);
         }
 
-        if let Some(token) = extra_token {
+        if let Some(token) = pending {
             self.process_token(token)?;
         }
 
@@ -1513,6 +1545,20 @@ fn should_skip_link_span(span: &Span, had_visible_text: bool) -> bool {
 /// italic).
 fn should_skip_empty_styled_span(span: &Span) -> bool {
     span.style != InlineStyle::None && span.style != InlineStyle::Link && !span.has_content()
+}
+
+/// Whether a token met while reading a `<dt>` ends the term rather than being
+/// flattened into it: the start of the next term or description, or the end of
+/// the list itself.
+fn closes_definition_term(token: &Token) -> bool {
+    let Some(element) = token.as_element() else {
+        return false;
+    };
+    let name = lowercase_name(element.name());
+    match token {
+        Token::EndElement(_) => matches!(name.as_str(), "dl" | "dd"),
+        _ => matches!(name.as_str(), "dl" | "dt" | "dd"),
+    }
 }
 
 fn lowercase_name(name: &str) -> String {
@@ -2173,6 +2219,61 @@ mod tests {
     }
 
     #[test]
+    fn parses_definition_term_with_block_content() {
+        // HTML5 allows flow content in `<dt>`. There is nowhere for a block to
+        // live inside a term, so wrappers are seen through and their text joins
+        // the term instead of leaking into the description.
+        let input = "<dl><dt><p>Apple</p></dt><dd>fruit</dd></dl>";
+        let document = parse(Cursor::new(input)).unwrap();
+
+        let items = document.paragraphs[0].definition_items();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].terms.len(), 1);
+        assert_eq!(items[0].terms[0][0].text, "Apple");
+        assert_eq!(items[0].definition.len(), 1);
+        assert_eq!(items[0].definition[0].content()[0].text, "fruit");
+    }
+
+    #[test]
+    fn parses_definition_term_with_several_blocks_and_markup() {
+        // Separate blocks in one term are joined by a line break, and inline
+        // markup inside a wrapper is kept.
+        let document = parse(Cursor::new(
+            "<dl><dt><p>Apple</p><p>Malus</p></dt><dd>fruit</dd>\
+             <dt><div><b>Pear</b> tree</div></dt><dd>also fruit</dd></dl>",
+        ))
+        .unwrap();
+
+        let items = document.paragraphs[0].definition_items();
+        assert_eq!(items.len(), 2);
+
+        let joined: String = items[0].terms[0].iter().map(|s| s.text.clone()).collect();
+        assert_eq!(joined, "Apple\nMalus");
+
+        assert_eq!(items[1].terms.len(), 1);
+        assert_eq!(items[1].terms[0][0].style, InlineStyle::Bold);
+        assert_eq!(items[1].terms[0][0].children[0].text, "Pear");
+        assert_eq!(items[1].terms[0][1].text, " tree");
+
+        // A wrapped term still round-trips through the HTML writer.
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let html = String::from_utf8(output).unwrap();
+        assert_eq!(parse(Cursor::new(&html)).unwrap(), document);
+    }
+
+    #[test]
+    fn parses_definition_term_wrapping_an_empty_block() {
+        // Nothing meaningful in the term, so the item keeps only its
+        // description rather than gaining an empty term.
+        let document = parse(Cursor::new("<dl><dt><p></p></dt><dd>fruit</dd></dl>")).unwrap();
+        let items = document.paragraphs[0].definition_items();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].terms.is_empty());
+        assert_eq!(items[0].definition.len(), 1);
+    }
+
+    #[test]
     fn parses_definition_description_with_block_content() {
         let input = "<dl><dt>Term</dt><dd><p>Intro</p><ul><li>one</li><li>two</li></ul></dd></dl>";
         let document = parse(Cursor::new(input)).unwrap();
@@ -2204,17 +2305,34 @@ mod tests {
     }
 
     #[test]
-    fn writes_multiple_definitions_as_separate_dd_elements() {
-        // A single item with several definition paragraphs emits one `<dd>` per
-        // paragraph, so the list round-trips through HTML.
+    fn writes_one_dd_per_definition_however_many_blocks_it_holds() {
+        // An item carries a single definition, so several `<dd>`s in the source
+        // fold into one on the way out, with each block kept as its own
+        // paragraph inside it.
         let input = "<dl><dt>Apple</dt><dd>Pomaceous fruit</dd><dd>A company</dd></dl>";
         let document = parse(Cursor::new(input)).unwrap();
         let mut output = Vec::new();
         write(&mut output, &document).unwrap();
+        let html = String::from_utf8(output).unwrap();
         assert_eq!(
-            String::from_utf8(output).unwrap(),
-            "<dl>\n  <dt>Apple</dt>\n  <dd>Pomaceous fruit</dd>\n  <dd>A company</dd>\n</dl>\n"
+            html,
+            "<dl>\n  <dt>Apple</dt>\n  <dd>\n    <p>Pomaceous fruit</p>\n\n    \
+             <p>A company</p>\n  </dd>\n</dl>\n"
         );
+
+        // Folding is idempotent: re-reading the output yields the same document.
+        assert_eq!(parse(Cursor::new(&html)).unwrap(), document);
+    }
+
+    #[test]
+    fn writes_a_term_without_a_definition_as_an_empty_dd() {
+        let input = "<dl><dt>Lonely</dt></dl>";
+        let document = parse(Cursor::new(input)).unwrap();
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let html = String::from_utf8(output).unwrap();
+        assert_eq!(html, "<dl>\n  <dt>Lonely</dt>\n  <dd></dd>\n</dl>\n");
+        assert_eq!(parse(Cursor::new(&html)).unwrap(), document);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod test_helpers;
 pub use document::Document;
 pub use inline::{InlineStyle, Span};
 pub use pager::*;
-pub use paragraph::{ChecklistItem, Paragraph, ParagraphType, TableCell, TableRow};
+pub use paragraph::{ChecklistItem, DefinitionItem, Paragraph, ParagraphType, TableCell, TableRow};
 
 /// Convenience result type used across parsing and writing APIs.
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,16 @@
 //! children. Nested checklist items are preserved end-to-end so complex task
 //! hierarchies round-trip across every parser and writer.
 //!
+//! Definition lists (HTML `<dl>`, or the PHP Markdown Extra `Term` / `:
+//! definition` syntax) map to [`ParagraphType::DefinitionList`] nodes holding
+//! [`DefinitionItem`] children, each pairing one or more terms with a single
+//! definition made of block paragraphs. Unlike checklists, they do not survive
+//! every format: FTML and Gemtext have no such element, so those writers
+//! flatten the structure into text, and Markdown cannot express several terms
+//! sharing one definition. See the
+//! [README](https://github.com/roblillack/tdoc#definition-lists) for what each
+//! writer does.
+//!
 //! Most applications start by building a [`Document`] manually or converting
 //! some source text via one of the format modules, manipulate or inspect the
 //! tree, and finally render it with [`ftml::Writer`], [`html::Writer`], or

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,6 +95,15 @@ macro_rules! __tdoc_build_block {
             "`hr` is not part of strict FTML; use the `doc!` macro for horizontal rules and other extensions"
         );
     }};
+    (doc, dl { $($inner:tt)* }) => {{
+        $crate::Paragraph::new_definition_list()
+            .with_definition_items(__tdoc_definition_items!($($inner)*))
+    }};
+    (ftml, dl { $($inner:tt)* }) => {{
+        compile_error!(
+            "`dl` is not part of strict FTML; use the `doc!` macro for definition lists and other extensions"
+        );
+    }};
     // --- Anything else is genuinely unknown ---
     ($mode:ident, $other:ident { $($inner:tt)* }) => {{
         compile_error!(concat!("Unknown document element: ", stringify!($other)));
@@ -409,6 +418,79 @@ macro_rules! __tdoc_table_cells_inner {
     ($vec:ident, $unexpected:tt $($rest:tt)*) => {{
         compile_error!(concat!(
             "Unexpected token inside table row: ",
+            stringify!($unexpected)
+        ));
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __tdoc_definition_items {
+    () => {
+        ::std::vec::Vec::<$crate::DefinitionItem>::new()
+    };
+    ($($tt:tt)*) => {{
+        let mut __items: ::std::vec::Vec<$crate::DefinitionItem> = ::std::vec::Vec::new();
+        __tdoc_definition_items_inner!(__items, $($tt)*);
+        __items
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __tdoc_definition_items_inner {
+    ($vec:ident,) => {};
+    ($vec:ident) => {};
+    ($vec:ident, , $($rest:tt)*) => {
+        __tdoc_definition_items_inner!($vec, $($rest)*);
+    };
+    ($vec:ident, item { $($inner:tt)* } $($rest:tt)*) => {{
+        let mut __item = $crate::DefinitionItem::new();
+        __tdoc_definition_item_inner!(__item, $($inner)*);
+        $vec.push(__item);
+        __tdoc_definition_items_inner!($vec, $($rest)*);
+    }};
+    ($vec:ident, $other:ident { $($inner:tt)* } $($rest:tt)*) => {{
+        compile_error!(concat!(
+            "Expected `item` inside definition list, found `",
+            stringify!($other),
+            "`"
+        ));
+    }};
+    ($vec:ident, $unexpected:tt $($rest:tt)*) => {{
+        compile_error!(concat!(
+            "Unexpected token inside definition list: ",
+            stringify!($unexpected)
+        ));
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export(local_inner_macros)]
+macro_rules! __tdoc_definition_item_inner {
+    ($item:ident,) => {};
+    ($item:ident) => {};
+    ($item:ident, , $($rest:tt)*) => {
+        __tdoc_definition_item_inner!($item, $($rest)*);
+    };
+    ($item:ident, term { $($inner:tt)* } $($rest:tt)*) => {{
+        $item.terms.push(__tdoc_inline_nodes!($($inner)*));
+        __tdoc_definition_item_inner!($item, $($rest)*);
+    }};
+    ($item:ident, def { $($inner:tt)* } $($rest:tt)*) => {{
+        $item.definition = __tdoc_collect_blocks!(doc; $($inner)*);
+        __tdoc_definition_item_inner!($item, $($rest)*);
+    }};
+    ($item:ident, $other:ident { $($inner:tt)* } $($rest:tt)*) => {{
+        compile_error!(concat!(
+            "Expected `term` or `def` inside definition item, found `",
+            stringify!($other),
+            "`"
+        ));
+    }};
+    ($item:ident, $unexpected:tt $($rest:tt)*) => {{
+        compile_error!(concat!(
+            "Unexpected token inside definition item: ",
             stringify!($unexpected)
         ));
     }};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -504,8 +504,9 @@ macro_rules! __tdoc_definition_item_inner {
 /// `checklist`, and fenced `code` blocks. Inline runs can contain string
 /// literals or inline tags like `b`, `i`, `mark`, `code`, and `link`.
 ///
-/// For tdoc's non-FTML extensions (such as `table`), use [`doc!`](macro@crate::doc),
-/// which understands the same syntax plus the extra elements.
+/// For tdoc's non-FTML extensions (`table`, `hr`, and `dl`), use
+/// [`doc!`](macro@crate::doc), which understands the same syntax plus the extra
+/// elements.
 ///
 /// # Examples
 ///
@@ -531,6 +532,16 @@ macro_rules! __tdoc_definition_item_inner {
 ///     table { row { td { "nope" } } }
 /// };
 /// ```
+///
+/// The same goes for `hr` and for definition lists:
+///
+/// ```compile_fail
+/// use tdoc::ftml;
+///
+/// let document = ftml! {
+///     dl { item { term { "nope" } def { p { "not strict FTML" } } } }
+/// };
+/// ```
 macro_rules! ftml {
     ($($tt:tt)*) => {{
         let __paragraphs = __tdoc_collect_blocks!(ftml; $($tt)*);
@@ -543,11 +554,13 @@ macro_rules! ftml {
 ///
 /// `doc!` is a superset of [`ftml!`](macro@crate::ftml): it accepts every element the
 /// strict macro does, plus tdoc's extensions that go beyond strict FTML. Today
-/// that means tables; it is also the place where future extensions are added.
+/// those are tables (`table`), horizontal rules (`hr`), and definition lists
+/// (`dl`); it is also the place where future extensions are added.
 ///
 /// Tables follow the same HTML-flavored syntax as the rest of the DSL: a
 /// `table` contains `row`s, and each `row` contains header cells (`th`) and data
-/// cells (`td`), each holding inline content.
+/// cells (`td`), each holding inline content. A horizontal rule is the empty
+/// `hr { }`.
 ///
 /// # Examples
 ///
@@ -560,11 +573,58 @@ macro_rules! ftml {
 ///         row { th { "Name" } th { "Score" } }
 ///         row { td { "Alice" } td { "42" } }
 ///     }
+///     hr { }
 /// };
 ///
 /// assert_eq!(document.paragraphs[0].paragraph_type(), ParagraphType::Header1);
 /// assert_eq!(document.paragraphs[1].paragraph_type(), ParagraphType::Table);
+/// assert_eq!(document.paragraphs[2].paragraph_type(), ParagraphType::HorizontalRule);
 /// ```
+///
+/// # Definition lists
+///
+/// A `dl` holds `item`s, and each item pairs one or more `term`s with a single
+/// `def`. A `term` takes inline content; a `def` takes block content, so a
+/// definition can hold several paragraphs, a list, a quote, or a code block:
+///
+/// ```
+/// use tdoc::{doc, ParagraphType};
+///
+/// let document = doc! {
+///     dl {
+///         item {
+///             term { "HTTP" }
+///             def { p { "HyperText Transfer Protocol" } }
+///         }
+///         item {
+///             term { "TCP" }
+///             term { "UDP" }
+///             def {
+///                 p { "Transport protocols." }
+///                 p { "Both carry ", b { "HTTP" }, "." }
+///             }
+///         }
+///     }
+/// };
+///
+/// let items = document.paragraphs[0].definition_items();
+/// assert_eq!(document.paragraphs[0].paragraph_type(), ParagraphType::DefinitionList);
+/// assert_eq!(items.len(), 2);
+/// assert_eq!(items[1].terms.len(), 2);
+/// assert_eq!(items[1].definition.len(), 2);
+/// ```
+///
+/// Repeating `term` adds terms that share the definition, mirroring consecutive
+/// `<dt>`s in HTML. Repeating `def`, by contrast, *replaces* the definition:
+/// an item carries exactly one, so several descriptions for the same term go in
+/// as several blocks of a single `def`. Both `term` and `def` may be omitted —
+/// a term with nothing to say, or a description with no term, are shapes HTML
+/// can express and the tree therefore keeps.
+///
+/// Note that not every format can represent all of this. Markdown has no
+/// spelling for several terms sharing one definition, and FTML and Gemtext have
+/// no definition lists at all, so writers degrade the structure as documented
+/// in the [README](https://github.com/roblillack/tdoc#definition-lists).
 macro_rules! doc {
     ($($tt:tt)*) => {{
         let __paragraphs = __tdoc_collect_blocks!(doc; $($tt)*);

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -2,7 +2,8 @@
 
 use crate::metadata;
 use crate::{
-    ChecklistItem, Document, InlineStyle, Paragraph, ParagraphType, Span, TableCell, TableRow,
+    ChecklistItem, DefinitionItem, Document, InlineStyle, Paragraph, ParagraphType, Span,
+    TableCell, TableRow,
 };
 use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use std::borrow::Cow;
@@ -44,6 +45,7 @@ pub fn parse<R: Read>(mut reader: R) -> crate::Result<Document> {
     options.insert(Options::ENABLE_TASKLISTS);
     options.insert(Options::ENABLE_WIKILINKS);
     options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_DEFINITION_LIST);
 
     let mut doc = build_document(content, options);
     doc.metadata = metadata;
@@ -63,6 +65,7 @@ pub fn parse_without_metadata<R: Read>(mut reader: R) -> crate::Result<Document>
     options.insert(Options::ENABLE_TASKLISTS);
     options.insert(Options::ENABLE_WIKILINKS);
     options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_DEFINITION_LIST);
 
     Ok(build_document(&input, options))
 }
@@ -234,6 +237,28 @@ impl MarkdownBuilder {
                             cells.push(cell);
                         }
                     }
+                    Some(BlockContext::DefinitionTitle { context }) => {
+                        let paragraph = context.finish();
+                        let term = match paragraph {
+                            Paragraph::Text { content } => content,
+                            _ => Vec::new(),
+                        };
+                        if let Some(BlockContext::DefinitionList { items }) = self.stack.last_mut()
+                        {
+                            add_definition_term(items, term);
+                        }
+                    }
+                    Some(BlockContext::DefinitionDefinition { paragraphs }) => {
+                        if let Some(BlockContext::DefinitionList { items }) = self.stack.last_mut()
+                        {
+                            add_definition_description(items, paragraphs);
+                        }
+                    }
+                    Some(BlockContext::DefinitionList { items }) => {
+                        let paragraph =
+                            Paragraph::new_definition_list().with_definition_items(items);
+                        self.add_paragraph_to_parent(paragraph);
+                    }
                     Some(BlockContext::Document { paragraphs }) => {
                         return Document {
                             metadata: None,
@@ -366,13 +391,22 @@ impl MarkdownBuilder {
                     context: ParagraphContext::new(ParagraphType::Text),
                 });
             }
-            Tag::HtmlBlock
-            | Tag::DefinitionList
-            | Tag::DefinitionListTitle
-            | Tag::DefinitionListDefinition
-            | Tag::Superscript
-            | Tag::Subscript
-            | Tag::MetadataBlock(_) => {
+            Tag::DefinitionList => {
+                self.close_open_paragraphs();
+                self.stack
+                    .push(BlockContext::DefinitionList { items: Vec::new() });
+            }
+            Tag::DefinitionListTitle => {
+                self.stack.push(BlockContext::DefinitionTitle {
+                    context: ParagraphContext::new(ParagraphType::Text),
+                });
+            }
+            Tag::DefinitionListDefinition => {
+                self.stack.push(BlockContext::DefinitionDefinition {
+                    paragraphs: Vec::new(),
+                });
+            }
+            Tag::HtmlBlock | Tag::Superscript | Tag::Subscript | Tag::MetadataBlock(_) => {
                 // Currently unsupported tags.
             }
         }
@@ -493,10 +527,34 @@ impl MarkdownBuilder {
                     self.add_paragraph_to_parent(paragraph);
                 }
             }
+            TagEnd::DefinitionListTitle => {
+                if let Some(BlockContext::DefinitionTitle { context }) = self.stack.pop() {
+                    let paragraph = context.finish();
+                    let term = match paragraph {
+                        Paragraph::Text { content } => content,
+                        _ => Vec::new(),
+                    };
+                    if let Some(BlockContext::DefinitionList { items }) = self.stack.last_mut() {
+                        add_definition_term(items, term);
+                    }
+                }
+            }
+            TagEnd::DefinitionListDefinition => {
+                self.close_open_paragraphs();
+                if let Some(BlockContext::DefinitionDefinition { paragraphs }) = self.stack.pop() {
+                    if let Some(BlockContext::DefinitionList { items }) = self.stack.last_mut() {
+                        add_definition_description(items, paragraphs);
+                    }
+                }
+            }
+            TagEnd::DefinitionList => {
+                self.close_open_paragraphs();
+                if let Some(BlockContext::DefinitionList { items }) = self.stack.pop() {
+                    let paragraph = Paragraph::new_definition_list().with_definition_items(items);
+                    self.add_paragraph_to_parent(paragraph);
+                }
+            }
             TagEnd::HtmlBlock
-            | TagEnd::DefinitionList
-            | TagEnd::DefinitionListTitle
-            | TagEnd::DefinitionListDefinition
             | TagEnd::MetadataBlock(_)
             | TagEnd::Superscript
             | TagEnd::Subscript => {
@@ -616,8 +674,16 @@ impl MarkdownBuilder {
     }
 
     fn current_paragraph_inline_end(&mut self, style: InlineStyle) {
-        if let Some(BlockContext::Paragraph(context)) = self.stack.last_mut() {
-            context.end_inline(style);
+        // Inline content accumulates in whichever context `ensure_paragraph`
+        // targets, so a closing style must be routed to the same one — a table
+        // cell or definition term as well as an ordinary paragraph. Otherwise a
+        // style closed mid-content (e.g. `*a* b`) would never be popped and the
+        // following text would leak inside it.
+        match self.stack.last_mut() {
+            Some(BlockContext::Paragraph(context))
+            | Some(BlockContext::TableCell { context, .. })
+            | Some(BlockContext::DefinitionTitle { context }) => context.end_inline(style),
+            _ => {}
         }
     }
 
@@ -683,12 +749,22 @@ impl MarkdownBuilder {
     }
 
     fn ensure_paragraph(&mut self) -> &mut ParagraphContext {
-        let in_cell = matches!(self.stack.last(), Some(BlockContext::TableCell { .. }));
-        if in_cell {
-            return match self.stack.last_mut() {
-                Some(BlockContext::TableCell { context, .. }) => context,
-                _ => unreachable!("TableCell context should exist"),
-            };
+        // Table cells and definition-list terms both accumulate inline content
+        // directly in their own context rather than in a nested paragraph.
+        match self.stack.last() {
+            Some(BlockContext::TableCell { .. }) => {
+                return match self.stack.last_mut() {
+                    Some(BlockContext::TableCell { context, .. }) => context,
+                    _ => unreachable!("TableCell context should exist"),
+                };
+            }
+            Some(BlockContext::DefinitionTitle { .. }) => {
+                return match self.stack.last_mut() {
+                    Some(BlockContext::DefinitionTitle { context }) => context,
+                    _ => unreachable!("DefinitionTitle context should exist"),
+                };
+            }
+            _ => {}
         }
 
         let needs_new = !matches!(self.stack.last(), Some(BlockContext::Paragraph(_)));
@@ -763,8 +839,13 @@ impl MarkdownBuilder {
                 BlockContext::TableCell { context, .. } => {
                     context.push_nested_paragraph(paragraph);
                 }
-                BlockContext::Table { .. } | BlockContext::TableRow { .. } => {
-                    // Tables only hold rows/cells; stray paragraphs are dropped.
+                BlockContext::DefinitionDefinition { paragraphs } => paragraphs.push(paragraph),
+                BlockContext::Table { .. }
+                | BlockContext::TableRow { .. }
+                | BlockContext::DefinitionList { .. }
+                | BlockContext::DefinitionTitle { .. } => {
+                    // These only hold their own structured children; a stray
+                    // block paragraph here has nowhere meaningful to go.
                 }
             }
         }
@@ -828,6 +909,15 @@ enum BlockContext {
         is_header: bool,
         context: ParagraphContext,
     },
+    DefinitionList {
+        items: Vec<DefinitionItem>,
+    },
+    DefinitionTitle {
+        context: ParagraphContext,
+    },
+    DefinitionDefinition {
+        paragraphs: Vec<Paragraph>,
+    },
 }
 
 fn is_open_tag(tag: &str, name: &str) -> bool {
@@ -838,6 +928,37 @@ fn is_open_tag(tag: &str, name: &str) -> bool {
 fn is_close_tag(tag: &str, name: &str) -> bool {
     let prefix = format!("</{}", name);
     tag.starts_with(&prefix) && tag.contains('>')
+}
+
+/// Records a definition-list term, starting a new item when the previous one
+/// already carries a definition so that consecutive terms are grouped together.
+fn add_definition_term(items: &mut Vec<DefinitionItem>, term: Vec<Span>) {
+    let start_new = items
+        .last()
+        .map(|item| !item.definition.is_empty())
+        .unwrap_or(true);
+    if start_new {
+        items.push(DefinitionItem::new());
+    }
+    items
+        .last_mut()
+        .expect("definition item present")
+        .terms
+        .push(term);
+}
+
+/// Folds a `<dd>`/`:` description into the current item's single definition as
+/// consecutive paragraphs, creating an item first if a description appears
+/// before any term.
+fn add_definition_description(items: &mut Vec<DefinitionItem>, paragraphs: Vec<Paragraph>) {
+    if items.is_empty() {
+        items.push(DefinitionItem::new());
+    }
+    items
+        .last_mut()
+        .expect("definition item present")
+        .definition
+        .extend(paragraphs);
 }
 
 struct ParagraphContext {
@@ -1165,6 +1286,53 @@ fn write_paragraph<W: Write>(
             // line, so `---` never fuses with a preceding paragraph to form a
             // setext heading underline.
             writeln!(writer, "{}---", prefix)?;
+        }
+        Paragraph::DefinitionList { items } => {
+            write_definition_list(writer, items, prefix, continuation_prefix)?;
+        }
+    }
+    Ok(())
+}
+
+/// Serializes a definition list using the PHP Markdown Extra / kramdown syntax
+/// understood by pulldown-cmark: each term on its own line, immediately
+/// followed by its descriptions, each introduced by a `: ` marker. Groups are
+/// separated by a blank line.
+fn write_definition_list<W: Write>(
+    writer: &mut W,
+    items: &[DefinitionItem],
+    prefix: &str,
+    continuation_prefix: &str,
+) -> std::io::Result<()> {
+    for (item_idx, item) in items.iter().enumerate() {
+        if item_idx > 0 {
+            if !continuation_prefix.is_empty() {
+                write!(writer, "{}", continuation_prefix)?;
+            }
+            writeln!(writer)?;
+        }
+
+        for (term_idx, term) in item.terms.iter().enumerate() {
+            let term_prefix = if item_idx == 0 && term_idx == 0 {
+                prefix
+            } else {
+                continuation_prefix
+            };
+            let content = render_spans_to_string(term)?;
+            write_wrapped_lines(writer, term_prefix, continuation_prefix, &content, false)?;
+        }
+
+        // Each paragraph of the definition is emitted as its own `: ` line, so
+        // a term with several definitions renders as several markers.
+        let definition_prefix = format!("{}: ", continuation_prefix);
+        let definition_continuation = format!("{}  ", continuation_prefix);
+        for paragraph in &item.definition {
+            write_paragraphs(
+                writer,
+                std::slice::from_ref(paragraph),
+                &definition_prefix,
+                &definition_continuation,
+            )?;
         }
     }
     Ok(())
@@ -2276,6 +2444,56 @@ mod tests {
         let rendered = String::from_utf8(output).unwrap();
         let reparsed = parse(Cursor::new(&rendered)).unwrap();
         assert_eq!(reparsed, document, "rendered as {rendered:?}");
+    }
+
+    #[test]
+    fn test_parse_definition_list() {
+        let input = "Apple\n: Pomaceous fruit\n: An American company\n\nOrange\n: Citrus fruit\n";
+        let parsed = parse(Cursor::new(input)).unwrap();
+        let expected = doc(vec![dl_(vec![
+            di_(
+                vec![spans("Apple")],
+                vec![p__("Pomaceous fruit"), p__("An American company")],
+            ),
+            di_(vec![spans("Orange")], vec![p__("Citrus fruit")]),
+        ])]);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn test_write_definition_list() {
+        let document = doc(vec![dl_(vec![
+            di_(
+                vec![spans("Apple")],
+                vec![p__("Pomaceous fruit"), p__("An American company")],
+            ),
+            di_(vec![spans("Orange")], vec![p__("Citrus fruit")]),
+        ])]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "Apple\n: Pomaceous fruit\n: An American company\n\nOrange\n: Citrus fruit\n"
+        );
+    }
+
+    #[test]
+    fn test_definition_list_round_trips() {
+        // Both the tight single-definition form and the multi-term / multi-def
+        // form must survive a Markdown round-trip unchanged.
+        for input in [
+            "Term\n: Definition\n",
+            "Coffee\n: Black hot drink\n\nMilk\n: White cold drink\n",
+            "Apple\n: Pomaceous fruit\n: An American company\n",
+        ] {
+            let parsed = parse(Cursor::new(input)).unwrap();
+            let mut output = Vec::new();
+            write(&mut output, &parsed).unwrap();
+            let rendered = String::from_utf8(output).unwrap();
+            assert_eq!(rendered, input, "round-trip changed the document");
+            let reparsed = parse(Cursor::new(&rendered)).unwrap();
+            assert_eq!(reparsed, parsed, "reparse differed for {input:?}");
+        }
     }
 
     #[test]

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1180,6 +1180,10 @@ fn write_paragraphs<W: Write>(
                 write!(writer, "{}", continuation_prefix)?;
             }
             writeln!(writer)?;
+
+            if needs_block_separator(&paragraphs[i - 1], paragraph) {
+                write_block_separator(writer, continuation_prefix)?;
+            }
         }
         let mut current_prefix = if i == 0 { prefix } else { continuation_prefix };
 
@@ -1195,6 +1199,52 @@ fn write_paragraphs<W: Write>(
         write_paragraph(writer, paragraph, current_prefix, continuation_prefix)?;
     }
     Ok(())
+}
+
+/// Writes the separator that keeps two adjacent blocks from being read as one:
+/// an HTML comment on its own line, then a blank line. The comment carries no
+/// visible content and is dropped again on import.
+fn write_block_separator<W: Write>(
+    writer: &mut W,
+    continuation_prefix: &str,
+) -> std::io::Result<()> {
+    writeln!(writer, "{}<!-- -->", continuation_prefix)?;
+    if !continuation_prefix.is_empty() {
+        write!(writer, "{}", continuation_prefix)?;
+    }
+    writeln!(writer)
+}
+
+/// Whether an HTML comment has to be written between `previous` and `current`
+/// to stop Markdown from reading the two as one block.
+///
+/// Both cases involve a definition list, because a blank line means something
+/// *inside* one: it is how items of the same list are separated. So two lists in
+/// a row would fuse into one, and a list whose first item has no term would take
+/// the block above it as that term — a `:` line binds to whatever precedes it. A
+/// comment breaks the adjacency in both cases without adding visible content.
+///
+/// Markdown has no spelling for a term-less description, so such a list still
+/// degrades to a paragraph on re-import; what the separator saves is the
+/// neighbour above it.
+fn needs_block_separator(previous: &Paragraph, current: &Paragraph) -> bool {
+    if !matches!(current, Paragraph::DefinitionList { .. }) {
+        return false;
+    }
+    matches!(previous, Paragraph::DefinitionList { .. }) || starts_without_a_term(current)
+}
+
+/// Whether a definition list opens with an item that has no term, which makes
+/// its leading `: ` line liable to attach to whatever precedes the list.
+fn starts_without_a_term(paragraph: &Paragraph) -> bool {
+    match paragraph {
+        Paragraph::DefinitionList { items } => items.first().is_some_and(|item| {
+            item.terms
+                .iter()
+                .all(|term| term.iter().all(|span| span.is_content_empty()))
+        }),
+        _ => false,
+    }
 }
 
 fn needs_block_prefix_line(paragraph: &Paragraph) -> bool {
@@ -1243,6 +1293,10 @@ fn write_paragraph<W: Write>(
                 if idx > 0 {
                     write!(writer, "{}", quote_continuation)?;
                     writeln!(writer)?;
+
+                    if needs_block_separator(&children[idx - 1], child) {
+                        write_block_separator(writer, &quote_continuation)?;
+                    }
                 }
                 write_paragraph(writer, child, &quote_prefix, &quote_continuation)?;
             }
@@ -1285,9 +1339,9 @@ fn write_paragraph<W: Write>(
 }
 
 /// Serializes a definition list using the PHP Markdown Extra / kramdown syntax
-/// understood by pulldown-cmark: each term on its own line, immediately
-/// followed by its descriptions, each introduced by a `: ` marker. Groups are
-/// separated by a blank line.
+/// understood by pulldown-cmark: each term on its own line, followed by its
+/// definition introduced by a single `: ` marker. Groups are separated by a
+/// blank line.
 fn write_definition_list<W: Write>(
     writer: &mut W,
     items: &[DefinitionItem],
@@ -1309,21 +1363,23 @@ fn write_definition_list<W: Write>(
                 continuation_prefix
             };
             let content = render_spans_to_string(term)?;
-            write_wrapped_lines(writer, term_prefix, continuation_prefix, &content, false)?;
+            // A term starts a line in block context, so a leading `-`, `#`, `>`
+            // or `1.` has to be escaped — otherwise it reparses as a list,
+            // heading or quote and the definition list falls apart.
+            write_wrapped_lines(writer, term_prefix, continuation_prefix, &content, true)?;
         }
 
-        // Each paragraph of the definition is emitted as its own `: ` line, so
-        // a term with several definitions renders as several markers.
+        // The definition is a single description however many blocks it holds:
+        // only the first one carries the `: ` marker, the rest are indented
+        // beneath it as continuation content.
         let definition_prefix = format!("{}: ", continuation_prefix);
         let definition_continuation = format!("{}  ", continuation_prefix);
-        for paragraph in &item.definition {
-            write_paragraphs(
-                writer,
-                std::slice::from_ref(paragraph),
-                &definition_prefix,
-                &definition_continuation,
-            )?;
-        }
+        write_paragraphs(
+            writer,
+            &item.definition,
+            &definition_prefix,
+            &definition_continuation,
+        )?;
     }
     Ok(())
 }
@@ -1933,6 +1989,11 @@ fn escape_block_start_token(token: &str) -> Cow<'_, str> {
         b'#' if token.len() <= 6 && bytes.iter().all(|&b| b == b'#') => prepend_backslash(token),
         // Blockquote: the space after '>' is optional, so any leading '>' qualifies.
         b'>' => prepend_backslash(token),
+        // Definition description: with definition lists enabled, a line opening
+        // with a colon is a description marker and binds to the paragraph above
+        // it. Neither the space after ':' nor any text before it is required —
+        // `:`, `: x` and `:x` all qualify — so any leading colon is escaped.
+        b':' => prepend_backslash(token),
         // Bullet list ('-'/'+'), thematic break ('---'), or setext underline: a run made
         // up only of dashes is ambiguous at line start, and escaping the leading dash
         // neutralizes every interpretation while preserving the exact dash count.
@@ -2529,20 +2590,23 @@ mod tests {
         ])]);
         let mut output = Vec::new();
         write(&mut output, &document).unwrap();
+        // An item's definition is one description, so only its first block
+        // carries the `: ` marker; later blocks are indented beneath it.
         assert_eq!(
             String::from_utf8(output).unwrap(),
-            "Apple\n: Pomaceous fruit\n: An American company\n\nOrange\n: Citrus fruit\n"
+            "Apple\n: Pomaceous fruit\n  \n  An American company\n\nOrange\n: Citrus fruit\n"
         );
     }
 
     #[test]
     fn test_definition_list_round_trips() {
-        // Both the tight single-definition form and the multi-term / multi-def
-        // form must survive a Markdown round-trip unchanged.
+        // These are the canonical shapes the writer emits, so they must survive
+        // a round-trip byte for byte.
         for input in [
             "Term\n: Definition\n",
             "Coffee\n: Black hot drink\n\nMilk\n: White cold drink\n",
-            "Apple\n: Pomaceous fruit\n: An American company\n",
+            "Apple\n: Pomaceous fruit\n  \n  An American company\n",
+            "Term\n: intro\n  \n  - one\n  - two\n",
         ] {
             let parsed = parse(Cursor::new(input)).unwrap();
             let mut output = Vec::new();
@@ -2551,6 +2615,200 @@ mod tests {
             assert_eq!(rendered, input, "round-trip changed the document");
             let reparsed = parse(Cursor::new(&rendered)).unwrap();
             assert_eq!(reparsed, parsed, "reparse differed for {input:?}");
+        }
+    }
+
+    #[test]
+    fn test_definition_list_multiple_markers_normalize_to_one_description() {
+        // Several `: ` markers under one term parse into a single definition of
+        // several blocks, so they are rewritten into the canonical indented
+        // form. The document is unchanged, only its spelling.
+        let input = "Apple\n: Pomaceous fruit\n: An American company\n";
+        let parsed = parse(Cursor::new(input)).unwrap();
+        let mut output = Vec::new();
+        write(&mut output, &parsed).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(
+            rendered,
+            "Apple\n: Pomaceous fruit\n  \n  An American company\n"
+        );
+        assert_eq!(parse(Cursor::new(&rendered)).unwrap(), parsed);
+    }
+
+    #[test]
+    fn test_paragraph_starting_with_a_colon_is_not_read_as_a_definition() {
+        // With definition lists enabled a line opening with a colon is a
+        // description marker that binds to the paragraph above it, so an
+        // ordinary paragraph beginning with one has to be escaped or the pair
+        // comes back as a definition list.
+        for text in [": x", ":x", "::x", ":", ":smile: hi"] {
+            let document = doc(vec![p__("hello"), p__(text)]);
+            let mut output = Vec::new();
+            write(&mut output, &document).unwrap();
+            let rendered = String::from_utf8(output).unwrap();
+            assert_eq!(
+                parse(Cursor::new(&rendered)).unwrap(),
+                document,
+                "paragraph {text:?} rendered as {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_term_less_definition_does_not_capture_the_paragraph_above() {
+        // A description with no term of its own — reachable from HTML as a
+        // stray `<dd>` — has no Markdown spelling, so the list itself degrades
+        // to a paragraph. What must not happen is the paragraph above being
+        // swallowed as the missing term.
+        let document = doc(vec![p__("hello"), dl_(vec![di_(vec![], vec![p__("x")])])]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "hello\n\n<!-- -->\n\n: x\n");
+
+        let reparsed = parse(Cursor::new(&rendered)).unwrap();
+        assert_eq!(
+            reparsed,
+            doc(vec![p__("hello"), p__(": x")]),
+            "the preceding paragraph must survive"
+        );
+
+        // The degradation converges: re-rendering keeps both paragraphs.
+        let mut output = Vec::new();
+        write(&mut output, &reparsed).unwrap();
+        let rerendered = String::from_utf8(output).unwrap();
+        assert_eq!(parse(Cursor::new(&rerendered)).unwrap(), reparsed);
+    }
+
+    #[test]
+    fn test_adjacent_definition_lists_stay_separate() {
+        // A blank line separates items *within* a list, so two lists written
+        // back to back would fuse into one on re-import.
+        let document = doc(vec![
+            dl_(vec![di_(vec![spans("A")], vec![p__("1")])]),
+            dl_(vec![di_(vec![spans("B")], vec![p__("2")])]),
+        ]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "A\n: 1\n\n<!-- -->\n\nB\n: 2\n");
+
+        let reparsed = parse(Cursor::new(&rendered)).unwrap();
+        assert_eq!(reparsed, document, "the two lists merged");
+
+        // And the separated form is a fixed point.
+        let mut output = Vec::new();
+        write(&mut output, &reparsed).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), rendered);
+    }
+
+    #[test]
+    fn test_three_adjacent_definition_lists_stay_separate() {
+        let document = doc(vec![
+            dl_(vec![di_(vec![spans("A")], vec![p__("1")])]),
+            dl_(vec![di_(vec![spans("B")], vec![p__("2")])]),
+            dl_(vec![di_(vec![spans("C")], vec![p__("3")])]),
+        ]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(parse(Cursor::new(&rendered)).unwrap(), document);
+    }
+
+    #[test]
+    fn test_adjacent_definition_lists_stay_separate_when_nested() {
+        // Blockquotes and list items write their children through their own
+        // loops, so the separator has to reach those too.
+        let lists = vec![
+            dl_(vec![di_(vec![spans("A")], vec![p__("1")])]),
+            dl_(vec![di_(vec![spans("B")], vec![p__("2")])]),
+        ];
+
+        let quoted = doc(vec![quote_(lists.clone())]);
+        let mut output = Vec::new();
+        write(&mut output, &quoted).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "> A\n> : 1\n> \n> <!-- -->\n> \n> B\n> : 2\n");
+        assert_eq!(parse(Cursor::new(&rendered)).unwrap(), quoted);
+
+        let in_item = doc(vec![ul_(vec![lists])]);
+        let mut output = Vec::new();
+        write(&mut output, &in_item).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "- A\n  : 1\n  \n  <!-- -->\n  \n  B\n  : 2\n");
+        assert_eq!(parse(Cursor::new(&rendered)).unwrap(), in_item);
+    }
+
+    #[test]
+    fn test_definition_lists_split_by_a_paragraph_need_no_separator() {
+        // Anything between the two lists already breaks the adjacency.
+        let document = doc(vec![
+            dl_(vec![di_(vec![spans("A")], vec![p__("1")])]),
+            p__("between"),
+            dl_(vec![di_(vec![spans("B")], vec![p__("2")])]),
+        ]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "A\n: 1\n\nbetween\n\nB\n: 2\n");
+        assert_eq!(parse(Cursor::new(&rendered)).unwrap(), document);
+    }
+
+    #[test]
+    fn test_definition_list_with_a_term_needs_no_separator() {
+        // The separator is only for the term-less case; an ordinary list must
+        // not be cluttered with it.
+        let document = doc(vec![
+            p__("hello"),
+            dl_(vec![di_(vec![spans("Apple")], vec![p__("fruit")])]),
+        ]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "hello\n\nApple\n: fruit\n");
+        assert_eq!(parse(Cursor::new(&rendered)).unwrap(), document);
+    }
+
+    #[test]
+    fn test_definition_list_terms_merge_on_a_markdown_round_trip() {
+        // Known dialect limitation, not a tdoc one: pulldown-cmark has no syntax
+        // for several terms sharing one definition (no case in its definition
+        // list spec emits consecutive `<dt>`s), so terms written on their own
+        // lines come back as a single term. HTML keeps them apart.
+        let document = doc(vec![dl_(vec![di_(
+            vec![spans("Beta"), spans("Gamma")],
+            vec![p__("Two greek letters")],
+        )])]);
+        let mut output = Vec::new();
+        write(&mut output, &document).unwrap();
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "Beta\nGamma\n: Two greek letters\n");
+
+        let reparsed = parse(Cursor::new(&rendered)).unwrap();
+        assert_eq!(
+            reparsed,
+            doc(vec![dl_(vec![di_(
+                vec![spans("Beta Gamma")],
+                vec![p__("Two greek letters")],
+            )])]),
+        );
+    }
+
+    #[test]
+    fn test_definition_list_escapes_block_markers_in_terms() {
+        // A term begins a line in block context, so a leading list, heading,
+        // quote or thematic-break marker has to be escaped — otherwise the term
+        // reparses as that block and the definition list falls apart.
+        for term in ["- Apple", "# Apple", "1. Apple", "> Apple", "---"] {
+            let document = doc(vec![dl_(vec![di_(vec![spans(term)], vec![p__("def")])])]);
+            let mut output = Vec::new();
+            write(&mut output, &document).unwrap();
+            let rendered = String::from_utf8(output).unwrap();
+            assert_eq!(
+                parse(Cursor::new(&rendered)).unwrap(),
+                document,
+                "term {term:?} rendered as {rendered:?}"
+            );
         }
     }
 

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -28,6 +28,8 @@ pub enum ParagraphType {
     Table,
     /// A horizontal rule / thematic break (`<hr>`).
     HorizontalRule,
+    /// A definition list (`<dl>`) pairing terms with their descriptions.
+    DefinitionList,
 }
 
 impl fmt::Display for ParagraphType {
@@ -44,6 +46,7 @@ impl fmt::Display for ParagraphType {
             ParagraphType::Quote => "Quote",
             ParagraphType::Table => "Table",
             ParagraphType::HorizontalRule => "Horizontal Rule",
+            ParagraphType::DefinitionList => "Definition List",
         };
         write!(f, "{}", s)
     }
@@ -77,6 +80,7 @@ impl ParagraphType {
             ParagraphType::Quote => "blockquote",
             ParagraphType::Table => "table",
             ParagraphType::HorizontalRule => "hr",
+            ParagraphType::DefinitionList => "dl",
         }
     }
 
@@ -93,6 +97,7 @@ impl ParagraphType {
             "blockquote" => Some(ParagraphType::Quote),
             "table" => Some(ParagraphType::Table),
             "hr" => Some(ParagraphType::HorizontalRule),
+            "dl" => Some(ParagraphType::DefinitionList),
             _ => None,
         }
     }
@@ -157,6 +162,8 @@ pub enum Paragraph {
     Table { rows: Vec<TableRow> },
     /// A horizontal rule / thematic break. Carries no content.
     HorizontalRule,
+    /// A definition list pairing one or more terms with their descriptions.
+    DefinitionList { items: Vec<DefinitionItem> },
 }
 
 impl Paragraph {
@@ -174,6 +181,7 @@ impl Paragraph {
             ParagraphType::Quote => Self::new_quote(),
             ParagraphType::Table => Self::new_table(),
             ParagraphType::HorizontalRule => Self::new_horizontal_rule(),
+            ParagraphType::DefinitionList => Self::new_definition_list(),
         }
     }
 
@@ -248,6 +256,11 @@ impl Paragraph {
         Self::HorizontalRule
     }
 
+    /// Convenience constructor for [`ParagraphType::DefinitionList`].
+    pub fn new_definition_list() -> Self {
+        Self::DefinitionList { items: Vec::new() }
+    }
+
     /// Returns the [`ParagraphType`] of the current paragraph.
     pub fn paragraph_type(&self) -> ParagraphType {
         match self {
@@ -262,6 +275,7 @@ impl Paragraph {
             Paragraph::Quote { .. } => ParagraphType::Quote,
             Paragraph::Table { .. } => ParagraphType::Table,
             Paragraph::HorizontalRule => ParagraphType::HorizontalRule,
+            Paragraph::DefinitionList { .. } => ParagraphType::DefinitionList,
         }
     }
 
@@ -422,6 +436,35 @@ impl Paragraph {
     pub fn add_row(&mut self, row: TableRow) {
         self.rows_mut().push(row);
     }
+
+    /// Returns the items of a definition-list paragraph (or an empty slice).
+    pub fn definition_items(&self) -> &[DefinitionItem] {
+        match self {
+            Paragraph::DefinitionList { items } => items,
+            _ => &[],
+        }
+    }
+
+    /// Returns mutable access to the items of a definition-list paragraph.
+    pub fn definition_items_mut(&mut self) -> &mut Vec<DefinitionItem> {
+        match self {
+            Paragraph::DefinitionList { items } => items,
+            _ => panic!("only definition-list paragraphs can hold definition items"),
+        }
+    }
+
+    /// Replaces the paragraph's definition-list items.
+    pub fn with_definition_items(self, items: Vec<DefinitionItem>) -> Self {
+        match self {
+            Paragraph::DefinitionList { .. } => Paragraph::DefinitionList { items },
+            _ => panic!("only definition-list paragraphs can hold definition items"),
+        }
+    }
+
+    /// Appends a single item to a definition-list paragraph.
+    pub fn add_definition_item(&mut self, item: DefinitionItem) {
+        self.definition_items_mut().push(item);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -525,6 +568,53 @@ impl ChecklistItem {
     /// Appends a nested checklist item.
     pub fn add_child(&mut self, child: ChecklistItem) {
         self.children.push(child);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+/// A single group within a [`Paragraph::DefinitionList`].
+///
+/// Each item pairs one or more terms (`<dt>`, inline content) with a single
+/// definition (`<dd>`) made of block [`Paragraph`]s. When a source document
+/// lists several definitions for the same term(s), they are folded into this
+/// one definition as separate paragraphs — HTML `<dd>`s and Markdown `:` lines
+/// alike. Grouping several terms together mirrors how definition lists are
+/// authored in both HTML and Markdown, where consecutive terms share the
+/// definition that follows them.
+pub struct DefinitionItem {
+    /// The terms being defined. Each term holds inline [`Span`] content.
+    pub terms: Vec<Vec<Span>>,
+    /// The definition for the terms, as a list of block [`Paragraph`]s. Multiple
+    /// source definitions are represented as consecutive paragraphs here.
+    pub definition: Vec<Paragraph>,
+}
+
+impl DefinitionItem {
+    /// Creates an empty definition item with no terms or definition.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replaces the item's terms.
+    pub fn with_terms(mut self, terms: Vec<Vec<Span>>) -> Self {
+        self.terms = terms;
+        self
+    }
+
+    /// Replaces the item's definition (its block paragraphs).
+    pub fn with_definition(mut self, definition: Vec<Paragraph>) -> Self {
+        self.definition = definition;
+        self
+    }
+
+    /// Appends a single term (inline content).
+    pub fn add_term(&mut self, term: Vec<Span>) {
+        self.terms.push(term);
+    }
+
+    /// Appends a single paragraph to the item's definition.
+    pub fn add_definition_paragraph(&mut self, paragraph: Paragraph) {
+        self.definition.push(paragraph);
     }
 }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,6 +1,6 @@
 //! Convenience constructors for assembling documents in tests.
 
-use crate::{Document, InlineStyle, Paragraph, Span};
+use crate::{DefinitionItem, Document, InlineStyle, Paragraph, Span};
 
 pub fn p__(s: &str) -> Paragraph {
     Paragraph::new_text().with_content(vec![span(s)])
@@ -44,6 +44,18 @@ pub fn quote_(children: Vec<Paragraph>) -> Paragraph {
 
 pub fn doc(children: Vec<Paragraph>) -> Document {
     Document::new().with_paragraphs(children)
+}
+
+pub fn dl_(items: Vec<DefinitionItem>) -> Paragraph {
+    Paragraph::new_definition_list().with_definition_items(items)
+}
+
+/// Builds a definition item from its terms (each a run of spans) and its
+/// definition (a run of block paragraphs).
+pub fn di_(terms: Vec<Vec<Span>>, definition: Vec<Paragraph>) -> DefinitionItem {
+    DefinitionItem::new()
+        .with_terms(terms)
+        .with_definition(definition)
 }
 
 pub fn span(txt: &str) -> Span {

--- a/tests/data/CREDITS.md
+++ b/tests/data/CREDITS.md
@@ -1,0 +1,44 @@
+# Test fixture provenance
+
+Some fixtures under `tests/data/` are third-party documents, kept verbatim or
+lightly adapted so that tdoc is exercised against real-world markup rather than
+hand-written samples only. This file records where each one came from and under
+what licence, so the provenance stays with the repository.
+
+Fixtures are **not** shipped in the published crate: `Cargo.toml` lists `tests/`
+under `exclude`, so nothing here is redistributed via crates.io.
+
+When adding a third-party fixture, add a row below with its source URL, the
+licence it is under, and the date it was retrieved. If a document was trimmed or
+restructured to make a useful fixture, say so in the notes.
+
+## Definition lists
+
+| Fixture | Source | Licence | Retrieved |
+| --- | --- | --- | --- |
+| `spec/definition_lists.txt` | [pulldown-cmark `pulldown-cmark/specs/definition_lists.txt`](https://github.com/pulldown-cmark/pulldown-cmark/blob/master/pulldown-cmark/specs/definition_lists.txt) | MIT | 2026-08-06 |
+| `html/mdn-dl-element.html` | [MDN Web Docs, `<dl>: The Description List element`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl) | Code samples: [CC0 1.0](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Attrib_copyright_license); prose: [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) | 2026-08-06 |
+| `markdown/definition-lists-markdown-extra.md` | [Michel Fortin, *PHP Markdown Extra*, "Definition Lists"](https://michelf.ca/projects/php-markdown/extra/#def-list) | Documentation for [PHP Markdown](https://github.com/michelf/php-markdown), which is [BSD-3-Clause](https://github.com/michelf/php-markdown/blob/lib/License.md); the page itself carries no explicit licence notice | 2026-08-06 |
+
+### Notes
+
+- **`spec/definition_lists.txt`** is verbatim. It is pulldown-cmark's own
+  conformance suite for definition lists, which matters because pulldown-cmark
+  *is* tdoc's Markdown engine — the file therefore defines exactly the dialect
+  tdoc inherits, including the deliberate omission of the `~` marker. Its 31
+  cases are driven by `tests/definition_lists.rs`. The suite is in turn derived
+  from [commonmark-hs](https://github.com/jgm/commonmark-hs) (BSD-3-Clause), as
+  the file header records.
+- **`html/mdn-dl-element.html`** collects the HTML code samples from the MDN
+  page into a single standalone document, with short linking prose adapted from
+  the same page. The samples were chosen because between them they cover every
+  structural shape the parser has to handle: one term with one description,
+  several terms sharing a description, one term with several descriptions, a
+  key-value metadata list, and name-value groups wrapped in `<div>` elements.
+- **`markdown/definition-lists-markdown-extra.md`** reproduces the Markdown
+  examples from the "Definition Lists" section of the PHP Markdown Extra
+  documentation, which is the syntax's normative description, arranged into one
+  document with headings. Note that some examples exercise behaviour
+  pulldown-cmark does not implement (notably several terms sharing one
+  definition); the snapshots record what tdoc actually does, not what Markdown
+  Extra would do.

--- a/tests/data/html/mdn-dl-element.html
+++ b/tests/data/html/mdn-dl-element.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>&lt;dl&gt;: The Description List element</title>
+  </head>
+  <body>
+    <h1>&lt;dl&gt;: The Description List element</h1>
+
+    <p>
+      The <code>&lt;dl&gt;</code> HTML element represents a description list. The
+      element encloses a list of groups of terms (specified using the
+      <code>&lt;dt&gt;</code> element) and descriptions (provided by
+      <code>&lt;dd&gt;</code> elements). Common uses for this element are to
+      implement a glossary or to display metadata (a list of key-value pairs).
+    </p>
+
+    <h2>Glossary</h2>
+
+    <p>Cryptids of Cornwall:</p>
+
+    <dl>
+      <dt>Beast of Bodmin</dt>
+      <dd>A large feline inhabiting Bodmin Moor.</dd>
+
+      <dt>Morgawr</dt>
+      <dd>A sea serpent.</dd>
+
+      <dt>Owlman</dt>
+      <dd>A giant owl-like creature.</dd>
+    </dl>
+
+    <h2>Single term and description</h2>
+
+    <dl>
+      <dt>Firefox</dt>
+      <dd>
+        A free, open source, cross-platform, graphical web browser developed by
+        the Mozilla Corporation and hundreds of volunteers.
+      </dd>
+
+      <!-- Other terms and descriptions -->
+    </dl>
+
+    <h2>Multiple terms, single description</h2>
+
+    <dl>
+      <dt>Firefox</dt>
+      <dt>Mozilla Firefox</dt>
+      <dt>Fx</dt>
+      <dd>
+        A free, open source, cross-platform, graphical web browser developed by
+        the Mozilla Corporation and hundreds of volunteers.
+      </dd>
+
+      <!-- Other terms and descriptions -->
+    </dl>
+
+    <h2>Single term, multiple descriptions</h2>
+
+    <dl>
+      <dt>Firefox</dt>
+      <dd>
+        A free, open source, cross-platform, graphical web browser developed by
+        the Mozilla Corporation and hundreds of volunteers.
+      </dd>
+      <dd>
+        The Red Panda also known as the Lesser Panda, Wah, Bear Cat or Firefox,
+        is a mostly herbivorous mammal, slightly larger than a domestic cat
+        (60 cm long).
+      </dd>
+
+      <!-- Other terms and descriptions -->
+    </dl>
+
+    <h2>Metadata</h2>
+
+    <p>
+      Description lists are useful for displaying metadata as a list of
+      key-value pairs.
+    </p>
+
+    <dl>
+      <dt>Name</dt>
+      <dd>Godzilla</dd>
+      <dt>Born</dt>
+      <dd>1952</dd>
+      <dt>Birthplace</dt>
+      <dd>Japan</dd>
+      <dt>Color</dt>
+      <dd>Green</dd>
+    </dl>
+
+    <h2>Wrapping name-value groups in div elements</h2>
+
+    <p>
+      HTML allows wrapping each name-value group in a <code>&lt;dl&gt;</code>
+      element in a <code>&lt;div&gt;</code> element. This can be useful when
+      using microdata, or when global attributes apply to a whole group, or for
+      styling purposes.
+    </p>
+
+    <dl>
+      <div>
+        <dt>Name</dt>
+        <dd>Godzilla</dd>
+      </div>
+      <div>
+        <dt>Born</dt>
+        <dd>1952</dd>
+      </div>
+      <div>
+        <dt>Birthplace</dt>
+        <dd>Japan</dd>
+      </div>
+      <div>
+        <dt>Color</dt>
+        <dd>Green</dd>
+      </div>
+    </dl>
+  </body>
+</html>

--- a/tests/data/markdown/definition-lists-markdown-extra.md
+++ b/tests/data/markdown/definition-lists-markdown-extra.md
@@ -1,0 +1,99 @@
+# Definition Lists
+
+Markdown Extra implements definition lists. Definition lists are made of terms
+and definitions of these terms, much like in a dictionary.
+
+A simple definition list in Markdown Extra is made of a single-line term
+followed by a colon and the definition for that term.
+
+Apple
+:   Pomaceous fruit of plants of the genus Malus in
+    the family Rosaceae.
+
+Orange
+:   The fruit of an evergreen tree of the genus Citrus.
+
+## Lazy continuation
+
+Terms must be separated from the previous definition by a blank line.
+Definitions can span on multiple lines, in which case they should be indented.
+But you don't really have to: if you want to be lazy, you could forget to indent
+a definition that span on multiple lines and it will still work:
+
+Apple
+:   Pomaceous fruit of plants of the genus Malus in
+the family Rosaceae.
+
+Orange
+:   The fruit of an evergreen tree of the genus Citrus.
+
+## Several definitions for one term
+
+Colons as definition markers typically start at the left margin, but may be
+indented by up to three spaces. Definition markers must be followed by one or
+more spaces or a tab.
+
+Definition lists can have more than one definition associated with one term:
+
+Apple
+:   Pomaceous fruit of plants of the genus Malus in
+    the family Rosaceae.
+:   An American computer company.
+
+Orange
+:   The fruit of an evergreen tree of the genus Citrus.
+
+## Several terms for one definition
+
+You can also associate more than one term to a definition:
+
+Term 1
+Term 2
+:   Definition a
+
+Term 3
+:   Definition b
+
+## Loose definitions
+
+If a definition is preceded by a blank line, Markdown Extra will wrap the
+definition in `<p>` tags in the HTML output. For example, this:
+
+Apple
+
+:   Pomaceous fruit of plants of the genus Malus in
+    the family Rosaceae.
+
+Orange
+
+:    The fruit of an evergreen tree of the genus Citrus.
+
+## Block-level content in definitions
+
+And just like regular list items, definitions can contain multiple paragraphs,
+and include other block-level elements such as blockquotes, code blocks, lists,
+and even other definition lists.
+
+Term 1
+
+:   This is a definition with two paragraphs. Lorem ipsum
+    dolor sit amet, consectetuer adipiscing elit. Aliquam
+    hendrerit mi posuere lectus.
+
+    Vestibulum enim wisi, viverra nec, fringilla in, laoreet
+    vitae, risus.
+
+:   Second definition for term 1, also wrapped in a paragraph
+    because of the blank line preceding it.
+
+Term 2
+
+:   This definition has a code block, a blockquote and a list.
+
+        code block.
+
+    > block quote
+    > on two lines.
+
+    1.  first list item
+    2.  second list item

--- a/tests/data/markdown/definition-lists-torture.md
+++ b/tests/data/markdown/definition-lists-torture.md
@@ -1,0 +1,100 @@
+# Definition list torture test
+
+Every definition-list shape the Markdown importer has to handle, in one
+document, so that a regression shows up as a diff rather than as a bug report.
+Each section is a separate list; the headings keep them apart.
+
+## One term, one definition
+
+Coffee
+: A hot black beverage
+
+## A definition of several paragraphs
+
+Firmware
+: Software written to a device's non-volatile memory.
+
+  Because it ships with the hardware, it is updated far less often than the
+  software running on top of it.
+
+## A list inside a definition
+
+Prerequisites
+: You will need:
+
+  - a Rust toolchain
+  - ten minutes
+
+## An indented code block inside a definition
+
+Layout
+:
+    The definition opens on the next line.
+
+        fn main() {}
+
+## A fenced code block, a quote, and a trailing paragraph
+
+Usage
+: Invoke the binary with a path:
+
+  > Output goes to the pager unless `--output` is given.
+
+  ```rust
+  println!("hello");
+  ```
+
+  That is the whole interface.
+
+## Several descriptions folding into one definition
+
+Milk
+: A cold white beverage
+: Best served chilled
+
+## A definition separated from its term by a blank line
+
+Latency
+
+: The delay before a transfer begins.
+
+## The tilde marker, which is deliberately not supported
+
+Strikethrough
+  ~ Some dialects accept `~` as a description marker. tdoc does not, because
+    pulldown-cmark spends `~` on strikethrough.
+
+## Inline styles in terms and definitions
+
+`--no-ansi`
+: Disable ANSI escapes. Useful when the terminal is *very* old, or when piping
+  into a file.
+
+**FTML**
+: The strict subset, described in the [README](https://example.com/readme).
+
+## Nested in a blockquote
+
+> Quoted intro.
+>
+> Blockquote
+> : A quoted definition list.
+
+## Nested in a list item
+
+- An item with its own list:
+
+  Item
+  : The definition sits inside the list item.
+
+- A plain second item.
+
+## Two lists separated only by a paragraph
+
+First
+: Ends here.
+
+An intervening paragraph, which keeps the two lists apart.
+
+Second
+: Starts here.

--- a/tests/data/spec/definition_lists.txt
+++ b/tests/data/spec/definition_lists.txt
@@ -1,0 +1,687 @@
+## Definition lists
+
+Based on https://github.com/jgm/commonmark-hs/blob/e3747fd282c806cd2f8e83226e85f1b83ee889c3/commonmark-extensions/test/definition_lists.md
+
+The term is given on a line by itself, followed by
+one or more definitions. Each definition must begin
+with `:` (after 0-2 spaces); subsequent lines must
+be indented unless they are lazy paragraph
+continuations.
+
+Commonmark-HS allows definition lists to use `~`.
+We can't do that, because we already use `~` for strikethrough.
+
+The list is tight if there is no blank line between
+the term and the first definition, otherwise loose.
+
+```````````````````````````````` example_deflists
+apple
+:   red fruit
+
+orange
+:   orange fruit
+.
+<dl>
+<dt>apple</dt>
+<dd>red fruit</dd>
+<dt>orange</dt>
+<dd>orange fruit</dd>
+</dl>
+````````````````````````````````
+
+Loose:
+
+```````````````````````````````` example_deflists
+apple
+
+:   red fruit
+
+orange
+
+:   orange fruit
+.
+<dl>
+<dt>apple</dt>
+<dd>
+<p>red fruit</p>
+</dd>
+<dt>orange</dt>
+<dd>
+<p>orange fruit</p>
+</dd>
+</dl>
+````````````````````````````````
+
+Also loose:
+
+```````````````````````````````` example_deflists
+apple
+
+:   red fruit
+.
+<dl>
+<dt>apple</dt>
+<dd>
+<p>red fruit</p>
+</dd>
+</dl>
+````````````````````````````````
+
+Indented marker:
+
+```````````````````````````````` example_deflists
+apple
+  : red fruit
+
+orange
+  : orange fruit
+.
+<dl>
+<dt>apple</dt>
+<dd>red fruit</dd>
+<dt>orange</dt>
+<dd>orange fruit</dd>
+</dl>
+````````````````````````````````
+
+```````````````````````````````` example_deflists
+apple
+
+ : red fruit
+
+orange
+
+ : orange fruit
+.
+<dl>
+<dt>apple</dt>
+<dd>
+<p>red fruit</p>
+</dd>
+<dt>orange</dt>
+<dd>
+<p>orange fruit</p>
+</dd>
+</dl>
+````````````````````````````````
+
+Multiple blocks in a definition:
+
+```````````````````````````````` example_deflists
+*apple*
+
+:   red fruit
+
+    contains seeds,
+    crisp, pleasant to taste
+
+*orange*
+
+:   orange fruit
+
+        { orange code block }
+
+    > orange block quote
+.
+<dl>
+<dt><em>apple</em></dt>
+<dd>
+<p>red fruit</p>
+<p>contains seeds,
+crisp, pleasant to taste</p>
+</dd>
+<dt><em>orange</em></dt>
+<dd>
+<p>orange fruit</p>
+<pre><code>{ orange code block }
+</code></pre>
+<blockquote>
+<p>orange block quote</p>
+</blockquote>
+</dd>
+</dl>
+````````````````````````````````
+
+Nested lists:
+
+```````````````````````````````` example_deflists
+term
+
+:   1. Para one
+
+       Para two
+.
+<dl>
+<dt>term</dt>
+<dd>
+<ol>
+<li><p>Para one</p>
+<p>Para two</p></li>
+</ol>
+</dd>
+</dl>
+````````````````````````````````
+
+Multiple definitions, tight:
+
+```````````````````````````````` example_deflists
+apple
+:   red fruit
+:   computer company
+
+orange
+:   orange fruit
+:   telecom company
+.
+<dl>
+<dt>apple</dt>
+<dd>red fruit</dd>
+<dd>computer company</dd>
+<dt>orange</dt>
+<dd>orange fruit</dd>
+<dd>telecom company</dd>
+</dl>
+````````````````````````````````
+
+Multiple definitions, loose:
+
+```````````````````````````````` example_deflists
+apple
+
+:   red fruit
+
+:   computer company
+
+orange
+
+:   orange fruit
+:   telecom company
+.
+<dl>
+<dt>apple</dt>
+<dd>
+<p>red fruit</p>
+</dd>
+<dd>
+<p>computer company</p>
+</dd>
+<dt>orange</dt>
+<dd>
+<p>orange fruit</p>
+</dd>
+<dd>
+<p>telecom company</p>
+</dd>
+</dl>
+````````````````````````````````
+
+Lazy line continuations:
+
+```````````````````````````````` example_deflists
+apple
+
+:   red fruit
+
+:   computer
+company
+
+orange
+
+:   orange
+fruit
+:   telecom company
+.
+<dl>
+<dt>apple</dt>
+<dd>
+<p>red fruit</p>
+</dd>
+<dd>
+<p>computer
+company</p>
+</dd>
+<dt>orange</dt>
+<dd>
+<p>orange
+fruit</p>
+</dd>
+<dd>
+<p>telecom company</p>
+</dd>
+</dl>
+````````````````````````````````
+
+A lazy continuation may start with a `:`, if it has enough indent.
+
+```````````````````````````````` example_deflists
+apple
+   : > computer company
+     : red fruit
+
+orange
+   : > telecom company
+   : orange fruit
+
+chili's
+   : > restaurant company
+ : spicy fruit
+.
+<dl>
+<dt>apple</dt>
+<dd><blockquote>
+<p>computer company
+: red fruit</p>
+</blockquote>
+</dd>
+<dt>orange</dt>
+<dd><blockquote>
+<p>telecom company</p>
+</blockquote>
+</dd>
+<dd>orange fruit</dd>
+<dt>chili's</dt>
+<dd><blockquote>
+<p>restaurant company</p>
+</blockquote>
+</dd>
+<dd>spicy fruit</dd>
+</dl>
+````````````````````````````````
+
+It may not, however, lazily act as a definition in a list.
+
+```````````````````````````````` example_deflists
+> cherry
+> : keyboard company
+> pomegranate
+: tart fruit
+.
+<blockquote>
+<dl>
+<dt>cherry</dt>
+<dd>keyboard company
+pomegranate
+: tart fruit</dd>
+</dl>
+</blockquote>
+````````````````````````````````
+
+Definition terms may span multiple lines:
+
+```````````````````````````````` example_deflists
+a
+b\
+c
+
+:   foo
+.
+<dl>
+<dt>a
+b<br />
+c</dt>
+<dd>
+<p>foo</p>
+</dd>
+</dl>
+````````````````````````````````
+
+Definition list with preceding paragraph
+(<https://github.com/jgm/commonmark-hs/issues/35>):
+
+```````````````````````````````` example_deflists
+Foo
+
+bar
+:   baz
+
+bim
+:   bor
+.
+<p>Foo</p>
+<dl>
+<dt>bar</dt>
+<dd>baz</dd>
+<dt>bim</dt>
+<dd>bor</dd>
+</dl>
+````````````````````````````````
+
+Definition list followed by paragraph.
+
+```````````````````````````````` example_deflists
+bar
+:   baz
+
+bim
+:   bor
+
+Bloze
+.
+<dl>
+<dt>bar</dt>
+<dd>baz</dd>
+<dt>bim</dt>
+<dd>bor</dd>
+</dl>
+<p>Bloze</p>
+````````````````````````````````
+
+The total indentation for a definition list cannot exceed four.
+This means you can't have one start with four spaces.
+
+```````````````````````````````` example_deflists
+bar
+    :baz
+
+Bloze
+.
+<p>bar
+:baz</p>
+<p>Bloze</p>
+````````````````````````````````
+
+You can follow one with four spaces,
+because it'll "eat" the three spaces after it.
+
+```````````````````````````````` example_deflists
+bar
+:    baz
+
+Bloze
+.
+<dl>
+<dt>bar</dt>
+<dd>baz</dd>
+</dl>
+<p>Bloze</p>
+````````````````````````````````
+
+To use an indented code block inside of a definition,
+you need to have five spaces of indentation after the colon.
+
+```````````````````````````````` example_deflists
+bar
+:       baz
+
+bar
+ :      baz
+
+bar
+  :     baz
+
+bar
+   :    baz
+
+bar
+    :   baz
+.
+<dl>
+<dt>bar</dt>
+<dd>
+<pre><code>  baz
+</code></pre>
+</dd>
+<dt>bar</dt>
+<dd>
+<pre><code> baz
+</code></pre>
+</dd>
+<dt>bar</dt>
+<dd>
+<pre><code>baz
+</code></pre>
+</dd>
+<dt>bar</dt>
+<dd>baz</dd>
+</dl>
+<p>bar
+:   baz</p>
+````````````````````````````````
+
+
+Because of the way it eats indentation after the colon, the number of
+spaces you need for indented code blocks on subsequent lines depends on
+the indentation of the earlier block.
+
+```````````````````````````````` example_deflists
+*orange*
+
+:   orange fruit
+
+        { orange code block }
+
+  > orange block quote
+
+*orange*
+
+:     orange fruit
+
+        { orange code block }
+
+  > orange block quote
+.
+<dl>
+<dt><em>orange</em></dt>
+<dd>
+<p>orange fruit</p>
+<pre><code>{ orange code block }
+</code></pre>
+</dd>
+</dl>
+<blockquote>
+<p>orange block quote</p>
+</blockquote>
+<dl>
+<dt><em>orange</em></dt>
+<dd>
+<pre><code>orange fruit
+
+  { orange code block }
+</code></pre>
+<blockquote>
+<p>orange block quote</p>
+</blockquote>
+</dd>
+</dl>
+````````````````````````````````
+
+Definition titles can't be tables.
+
+```````````````````````````````` example_deflists
+Test|Table
+----|-----
+: first
+.
+<table><thead><tr><th>Test</th><th>Table</th></tr></thead><tbody>
+<tr><td>: first</td><td></td></tr>
+</tbody>
+</table>
+````````````````````````````````
+
+```````````````````````````````` example_deflists
+first
+: second
+
+Test|Table
+----|-----
+: fourth
+.
+<dl>
+<dt>first</dt>
+<dd>second</dd>
+</dl>
+<table><thead><tr><th>Test</th><th>Table</th></tr></thead><tbody>
+<tr><td>: fourth</td><td></td></tr>
+</tbody>
+</table>
+````````````````````````````````
+
+
+Definition titles can't be headers
+
+```````````````````````````````` example_deflists
+My section
+==========
+: first
+.
+<h1>My section</h1>
+<p>: first</p>
+````````````````````````````````
+
+```````````````````````````````` example_deflists
+first
+: second
+
+My section
+==========
+: fourth
+.
+<dl>
+<dt>first</dt>
+<dd>second</dd>
+</dl>
+<h1>My section</h1>
+<p>: fourth</p>
+````````````````````````````````
+
+```````````````````````````````` example_deflists
+## My subsection
+: first
+.
+<h2>My subsection</h2>
+<p>: first</p>
+````````````````````````````````
+
+```````````````````````````````` example_deflists
+first
+: second
+
+## My subsection
+: fourth
+.
+<dl>
+<dt>first</dt>
+<dd>second</dd>
+</dl>
+<h2>My subsection</h2>
+<p>: fourth</p>
+````````````````````````````````
+
+
+Definition list titles can't be block quotes
+
+```````````````````````````````` example_deflists
+> first
+: second
+.
+<blockquote>
+<p>first
+: second</p>
+</blockquote>
+````````````````````````````````
+
+
+Definition titles can't end with hard line breaks.
+
+```````````````````````````````` example_deflists
+first\
+: second
+
+third  
+: fourth
+.
+<dl>
+<dt>first\</dt>
+<dd>second</dd>
+<dt>third</dt>
+<dd>fourth</dd>
+</dl>
+````````````````````````````````
+
+
+Definition titles can't be HTML blocks, but inline's fine.
+
+```````````````````````````````` example_deflists
+<div>first</div>
+: second
+
+first
+: second
+<div>third</div>
+: fourth
+.
+<div>first</div>
+: second
+<dl>
+<dt>first</dt>
+<dd>second</dd>
+</dl>
+<div>third</div>
+: fourth
+````````````````````````````````
+
+```````````````````````````````` example_deflists
+<span>first</span>
+: second
+
+third
+: fourth
+
+<span>fifth</span>
+: sixth
+.
+<dl>
+<dt><span>first</span></dt>
+<dd>second</dd>
+<dt>third</dt>
+<dd>fourth</dd>
+<dt><span>fifth</span></dt>
+<dd>sixth</dd>
+</dl>
+````````````````````````````````
+
+Nested definition lists:
+(<https://github.com/pulldown-cmark/pulldown-cmark/issues/973>):
+
+```````````````````````````````` example_deflists
+level one
+: l1
+    level two
+    : l2
+        level three
+        : l3
+
+level one
+: l1
+.
+<dl>
+<dt>level one</dt>
+<dd>
+<dl>
+<dt>l1
+level two</dt>
+<dd>
+<dl>
+<dt>l2
+level three</dt>
+<dd>l3</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt>level one</dt>
+<dd>l1</dd>
+</dl>
+````````````````````````````````
+
+https://github.com/pulldown-cmark/pulldown-cmark/issues/997
+
+Definition lists combined with link refdef
+
+```````````````````````````````` example_deflists
+[a]: /url
+    
+:
+.
+<p>:</p>
+````````````````````````````````

--- a/tests/definition_lists.rs
+++ b/tests/definition_lists.rs
@@ -1,0 +1,333 @@
+//! Drives tdoc against pulldown-cmark's own definition-list conformance suite.
+//!
+//! `tests/data/spec/definition_lists.txt` is a verbatim copy of the spec file
+//! that generates pulldown-cmark's `definition_lists` tests. Since
+//! pulldown-cmark is tdoc's Markdown engine, that file describes exactly the
+//! dialect tdoc inherits, which makes it the right corpus to hold the Markdown
+//! importer and writer against. See `tests/data/CREDITS.md` for provenance.
+//!
+//! Each case asserts the property that matters for a document toolkit: parsing
+//! a document and writing it back out must not change what the document *is*.
+//! The rendered Markdown itself is snapshotted so that changes to the writer's
+//! output are reviewed rather than discovered.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use tdoc::{markdown, Document, Paragraph};
+
+const SPEC: &str = include_str!("data/spec/definition_lists.txt");
+
+/// Spec cases that do not survive a Markdown round-trip today, each for a
+/// reason that has nothing to do with definition lists themselves. They are
+/// listed here rather than silently skipped, and
+/// [`every_spec_case_parses_and_round_trips`] asserts that each one still
+/// fails — so whoever fixes the underlying limitation is told to remove it.
+const KNOWN_ROUND_TRIP_GAPS: &[(usize, &str)] = &[
+    (
+        19,
+        "indented code blocks re-split their inline spans on reparse; the code text is \
+         identical, only its span segmentation differs",
+    ),
+    (
+        28,
+        "raw HTML blocks are not supported by the importer, so `<div>` terms come back as \
+         escaped text",
+    ),
+    (
+        31,
+        "a link reference definition plus a bare `:` yields an empty definition list, and an \
+         empty list is dropped when written",
+    ),
+];
+
+struct SpecCase {
+    number: usize,
+    input: String,
+    expected_html: String,
+}
+
+/// Splits the spec file into its examples.
+///
+/// The format is a long backtick fence opened with `example_deflists`, holding
+/// the Markdown input and the reference HTML separated by a lone `.` line.
+fn parse_spec(spec: &str) -> Vec<SpecCase> {
+    let mut cases = Vec::new();
+    let mut lines = spec.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim_end();
+        let is_open = trimmed.starts_with("````")
+            && trimmed.trim_start_matches('`').trim() == "example_deflists";
+        if !is_open {
+            continue;
+        }
+        let fence = &trimmed[..trimmed.len() - trimmed.trim_start_matches('`').len()];
+
+        let mut input = String::new();
+        let mut expected_html = String::new();
+        let mut past_separator = false;
+
+        for body in lines.by_ref() {
+            if body.trim_end() == fence {
+                break;
+            }
+            if body == "." && !past_separator {
+                past_separator = true;
+                continue;
+            }
+            let target = if past_separator {
+                &mut expected_html
+            } else {
+                &mut input
+            };
+            target.push_str(body);
+            target.push('\n');
+        }
+
+        cases.push(SpecCase {
+            number: cases.len() + 1,
+            input,
+            expected_html,
+        });
+    }
+
+    cases
+}
+
+fn render_markdown(document: &Document) -> String {
+    let mut output = Vec::new();
+    markdown::write(&mut output, document).expect("failed to write Markdown");
+    String::from_utf8(output).expect("Markdown output is not UTF-8")
+}
+
+fn count_definition_lists(paragraphs: &[Paragraph]) -> usize {
+    paragraphs
+        .iter()
+        .map(|paragraph| match paragraph {
+            Paragraph::DefinitionList { items } => {
+                1 + items
+                    .iter()
+                    .map(|item| count_definition_lists(&item.definition))
+                    .sum::<usize>()
+            }
+            Paragraph::Quote { children } => count_definition_lists(children),
+            Paragraph::UnorderedList { entries } | Paragraph::OrderedList { entries } => {
+                entries.iter().map(|e| count_definition_lists(e)).sum()
+            }
+            _ => 0,
+        })
+        .sum()
+}
+
+#[test]
+fn spec_file_is_present_and_parses() {
+    let cases = parse_spec(SPEC);
+    assert_eq!(
+        cases.len(),
+        31,
+        "unexpected number of spec cases — was tests/data/spec/definition_lists.txt updated?"
+    );
+    assert!(
+        cases.iter().all(|case| !case.input.is_empty()),
+        "every spec case must carry a Markdown input"
+    );
+    assert!(
+        cases.iter().all(|case| !case.expected_html.is_empty()),
+        "every spec case must carry reference HTML"
+    );
+}
+
+/// Parses `input`, writes it back, and reports what (if anything) the
+/// round-trip changed.
+fn round_trip_failure(case: &SpecCase) -> Option<String> {
+    let parsed = match markdown::parse(Cursor::new(case.input.as_bytes())) {
+        Ok(document) => document,
+        Err(err) => return Some(format!("case {}: failed to parse: {err}", case.number)),
+    };
+
+    let rendered = render_markdown(&parsed);
+
+    let reparsed = match markdown::parse(Cursor::new(rendered.as_bytes())) {
+        Ok(document) => document,
+        Err(err) => return Some(format!("case {}: failed to reparse: {err}", case.number)),
+    };
+
+    if reparsed != parsed {
+        return Some(format!(
+            "case {}: round-trip changed the document\n  input:    {:?}\n  rendered: {:?}",
+            case.number, case.input, rendered
+        ));
+    }
+
+    // Writing a second time must be a fixed point: the canonical form the
+    // writer emits has to survive re-rendering byte for byte.
+    let rerendered = render_markdown(&reparsed);
+    if rerendered != rendered {
+        return Some(format!(
+            "case {}: writer is not idempotent\n  first:  {:?}\n  second: {:?}",
+            case.number, rendered, rerendered
+        ));
+    }
+
+    None
+}
+
+#[test]
+fn every_spec_case_parses_and_round_trips() {
+    let cases = parse_spec(SPEC);
+    let mut failures = Vec::new();
+
+    for case in &cases {
+        let known_gap = KNOWN_ROUND_TRIP_GAPS
+            .iter()
+            .find(|(number, _)| *number == case.number);
+        let failure = round_trip_failure(case);
+
+        match (known_gap, failure) {
+            // A tracked gap that is still a gap: nothing to report, but say so
+            // out loud rather than skipping in silence.
+            (Some((number, reason)), Some(_)) => {
+                eprintln!("skipping known round-trip gap, case {number}: {reason}");
+            }
+            (Some((number, reason)), None) => failures.push(format!(
+                "case {number} now round-trips — remove it from KNOWN_ROUND_TRIP_GAPS \
+                 (was: {reason})"
+            )),
+            (None, Some(failure)) => failures.push(failure),
+            (None, None) => {}
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} spec cases failed:\n\n{}",
+        failures.len(),
+        cases.len(),
+        failures.join("\n\n")
+    );
+}
+
+#[test]
+fn spec_cases_that_define_a_list_are_imported_as_one() {
+    // The reference HTML tells us which cases are supposed to yield a `<dl>`.
+    // Those must import as a definition list rather than degrading to text,
+    // otherwise the importer silently stops recognizing the syntax.
+    let cases = parse_spec(SPEC);
+    let mut missing = Vec::new();
+
+    for case in &cases {
+        let expects_dl = case.expected_html.contains("<dl>");
+        let parsed =
+            markdown::parse(Cursor::new(case.input.as_bytes())).expect("failed to parse spec case");
+        let found = count_definition_lists(&parsed.paragraphs) > 0;
+
+        if expects_dl && !found {
+            missing.push(format!(
+                "case {}: reference HTML has a <dl> but tdoc produced none\n  input: {:?}",
+                case.number, case.input
+            ));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "{} spec cases lost their definition list:\n\n{}",
+        missing.len(),
+        missing.join("\n\n")
+    );
+}
+
+#[test]
+fn spec_markdown_output_snapshot() {
+    let cases = parse_spec(SPEC);
+    let mut report = String::new();
+
+    for case in &cases {
+        let parsed =
+            markdown::parse(Cursor::new(case.input.as_bytes())).expect("failed to parse spec case");
+        report.push_str(&format!("=== case {} ===\n", case.number));
+        report.push_str("--- input ---\n");
+        report.push_str(&case.input);
+        report.push_str("--- tdoc markdown ---\n");
+        report.push_str(&render_markdown(&parsed));
+        report.push('\n');
+    }
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("snapshots/markdown");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        insta::assert_snapshot!("definition_lists_spec", report);
+    });
+}
+
+#[test]
+fn markdown_extra_fixture_html_snapshot() {
+    // `markdown_import.rs` snapshots every Markdown fixture as FTML, which has
+    // no `<dl>` and so flattens definition lists into paragraphs. Snapshot this
+    // one through HTML as well, where the structure survives and a regression
+    // in the importer would actually show up.
+    let source = std::fs::read_to_string("tests/data/markdown/definition-lists-markdown-extra.md")
+        .expect("missing Markdown Extra fixture");
+    let document =
+        markdown::parse(Cursor::new(source.as_bytes())).expect("failed to parse the fixture");
+
+    assert!(
+        count_definition_lists(&document.paragraphs) >= 5,
+        "expected the Markdown Extra fixture to import several definition lists"
+    );
+
+    let mut rendered = Vec::new();
+    tdoc::html::write(&mut rendered, &document).expect("failed to render HTML");
+    let html = String::from_utf8(rendered).expect("HTML output is not UTF-8");
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("snapshots/markdown");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        insta::assert_snapshot!("definition-lists-markdown-extra.html", html);
+    });
+}
+
+#[test]
+fn mdn_fixture_survives_an_html_round_trip() {
+    // Every structural shape MDN documents for `<dl>` — shared descriptions,
+    // several descriptions per term, `<div>`-wrapped groups — has to come back
+    // unchanged through the HTML writer.
+    let file = std::fs::File::open("tests/data/html/mdn-dl-element.html")
+        .expect("missing MDN <dl> fixture");
+    let document = tdoc::html::parse(file).expect("failed to parse the fixture");
+
+    assert!(
+        count_definition_lists(&document.paragraphs) >= 6,
+        "expected the MDN fixture to import every one of its definition lists"
+    );
+
+    let mut rendered = Vec::new();
+    tdoc::html::write(&mut rendered, &document).expect("failed to render HTML");
+
+    let reparsed = tdoc::html::parse(Cursor::new(&rendered)).expect("failed to reparse HTML");
+    assert_eq!(
+        reparsed, document,
+        "the MDN definition lists changed on an HTML round-trip"
+    );
+}
+
+#[test]
+fn spec_fixture_provenance_is_recorded() {
+    // A third-party fixture without its licence and source recorded is a
+    // liability; keep the credits file honest.
+    let credits = std::fs::read_to_string(PathBuf::from("tests/data/CREDITS.md"))
+        .expect("tests/data/CREDITS.md must exist");
+    for fixture in [
+        "spec/definition_lists.txt",
+        "html/mdn-dl-element.html",
+        "markdown/definition-lists-markdown-extra.md",
+    ] {
+        assert!(
+            credits.contains(fixture),
+            "tests/data/CREDITS.md does not record the origin of {fixture}"
+        );
+    }
+}

--- a/tests/definition_lists.rs
+++ b/tests/definition_lists.rs
@@ -14,9 +14,15 @@
 use std::io::Cursor;
 use std::path::PathBuf;
 
-use tdoc::{markdown, Document, Paragraph};
+use tdoc::formatter::Formatter;
+use tdoc::{markdown, Document, Paragraph, ParagraphType};
 
 const SPEC: &str = include_str!("data/spec/definition_lists.txt");
+
+/// A first-party fixture collecting every shape the importer has to handle into
+/// one document. The spec suite covers each construct in isolation; this covers
+/// them together, and carries them through every writer.
+const TORTURE_FIXTURE: &str = "tests/data/markdown/definition-lists-torture.md";
 
 /// Spec cases that do not survive a Markdown round-trip today, each for a
 /// reason that has nothing to do with definition lists themselves. They are
@@ -102,22 +108,31 @@ fn render_markdown(document: &Document) -> String {
 }
 
 fn count_definition_lists(paragraphs: &[Paragraph]) -> usize {
-    paragraphs
-        .iter()
-        .map(|paragraph| match paragraph {
+    collect_definition_lists(paragraphs).len()
+}
+
+/// Collects every definition list in `paragraphs`, descending into definitions,
+/// quotes, and list items so nested lists are found too.
+fn collect_definition_lists(paragraphs: &[Paragraph]) -> Vec<&Paragraph> {
+    let mut found = Vec::new();
+    for paragraph in paragraphs {
+        match paragraph {
             Paragraph::DefinitionList { items } => {
-                1 + items
-                    .iter()
-                    .map(|item| count_definition_lists(&item.definition))
-                    .sum::<usize>()
+                found.push(paragraph);
+                for item in items {
+                    found.extend(collect_definition_lists(&item.definition));
+                }
             }
-            Paragraph::Quote { children } => count_definition_lists(children),
+            Paragraph::Quote { children } => found.extend(collect_definition_lists(children)),
             Paragraph::UnorderedList { entries } | Paragraph::OrderedList { entries } => {
-                entries.iter().map(|e| count_definition_lists(e)).sum()
+                for entry in entries {
+                    found.extend(collect_definition_lists(entry));
+                }
             }
-            _ => 0,
-        })
-        .sum()
+            _ => {}
+        }
+    }
+    found
 }
 
 #[test]
@@ -312,6 +327,217 @@ fn mdn_fixture_survives_an_html_round_trip() {
         reparsed, document,
         "the MDN definition lists changed on an HTML round-trip"
     );
+}
+
+/// Loads the torture fixture and returns the parsed document.
+fn torture_document() -> Document {
+    let source = std::fs::read_to_string(TORTURE_FIXTURE).expect("missing torture fixture");
+    markdown::parse(Cursor::new(source.as_bytes())).expect("failed to parse the torture fixture")
+}
+
+/// The block types appearing inside any definition of `paragraphs`.
+fn definition_block_types(paragraphs: &[Paragraph]) -> Vec<ParagraphType> {
+    collect_definition_lists(paragraphs)
+        .iter()
+        .flat_map(|list| list.definition_items())
+        .flat_map(|item| item.definition.iter())
+        .map(|block| block.paragraph_type())
+        .collect()
+}
+
+#[test]
+fn torture_fixture_keeps_every_shape_it_documents() {
+    // Structural assertions, so a writer or parser change that quietly drops one
+    // of the shapes fails here with a name attached rather than only showing up
+    // as an unexplained snapshot diff.
+    let document = torture_document();
+    let lists = collect_definition_lists(&document.paragraphs);
+
+    // One list per section that defines something, plus the two nested ones,
+    // minus the tilde section (which is not a list at all). The two groups of
+    // the inline-styles section are adjacent, so they form a single list.
+    assert_eq!(
+        lists.len(),
+        12,
+        "the fixture no longer imports as the definition lists it documents"
+    );
+    let items_per_list: Vec<usize> = lists
+        .iter()
+        .map(|list| list.definition_items().len())
+        .collect();
+    assert!(
+        items_per_list.contains(&2),
+        "expected the two adjacent groups of the inline-styles section to share one list, \
+         got item counts {items_per_list:?}"
+    );
+
+    // A definition holding several paragraphs, and one holding several
+    // descriptions folded into a single definition, both land as multi-block
+    // definitions.
+    let multi_block = lists
+        .iter()
+        .flat_map(|list| list.definition_items())
+        .filter(|item| item.definition.len() > 1)
+        .count();
+    assert!(
+        multi_block >= 4,
+        "expected several definitions to hold more than one block, found {multi_block}"
+    );
+
+    // Block content the fixture puts inside definitions must survive as blocks
+    // rather than being flattened into the surrounding text.
+    let block_types = definition_block_types(&document.paragraphs);
+    for expected in [
+        ParagraphType::Text,
+        ParagraphType::UnorderedList,
+        ParagraphType::CodeBlock,
+        ParagraphType::Quote,
+    ] {
+        assert!(
+            block_types.contains(&expected),
+            "no definition in the fixture holds a {expected:?} block"
+        );
+    }
+
+    // The `~` marker is deliberately unsupported, so that section must *not*
+    // have produced a list; it stays an ordinary paragraph.
+    let tilde_paragraphs = document
+        .paragraphs
+        .iter()
+        .filter(|paragraph| {
+            paragraph.paragraph_type() == ParagraphType::Text
+                && paragraph
+                    .content()
+                    .iter()
+                    .any(|span| span.text.contains('~'))
+        })
+        .count();
+    assert_eq!(
+        tilde_paragraphs, 1,
+        "the tilde section must stay a paragraph — supporting `~` would be a dialect change"
+    );
+}
+
+#[test]
+fn torture_fixture_survives_a_markdown_round_trip() {
+    let document = torture_document();
+
+    let rendered = render_markdown(&document);
+    let reparsed =
+        markdown::parse(Cursor::new(rendered.as_bytes())).expect("failed to reparse the fixture");
+    assert_eq!(
+        reparsed, document,
+        "the torture fixture changed on a Markdown round-trip"
+    );
+
+    // And the rendered form has to be a fixed point, so repeated conversions do
+    // not keep rewriting the file.
+    assert_eq!(
+        render_markdown(&reparsed),
+        rendered,
+        "the Markdown writer is not idempotent on the torture fixture"
+    );
+}
+
+#[test]
+fn torture_fixture_survives_an_html_round_trip() {
+    // Markdown and HTML disagree about what a definition list can express, so
+    // this is the crossing where structure is most likely to be lost.
+    let document = torture_document();
+
+    let mut rendered = Vec::new();
+    tdoc::html::write(&mut rendered, &document).expect("failed to render HTML");
+    let reparsed = tdoc::html::parse(Cursor::new(&rendered)).expect("failed to reparse HTML");
+
+    let before = collect_definition_lists(&document.paragraphs).len();
+    let after = collect_definition_lists(&reparsed.paragraphs).len();
+    assert_eq!(
+        after, before,
+        "an HTML round-trip changed how many definition lists the document has"
+    );
+    assert_eq!(
+        definition_block_types(&reparsed.paragraphs),
+        definition_block_types(&document.paragraphs),
+        "an HTML round-trip changed the block content of the definitions"
+    );
+}
+
+#[test]
+fn torture_fixture_markdown_snapshot() {
+    let rendered = render_markdown(&torture_document());
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("snapshots/markdown");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        insta::assert_snapshot!("definition-lists-torture.md", rendered);
+    });
+}
+
+#[test]
+fn torture_fixture_html_snapshot() {
+    let mut rendered = Vec::new();
+    tdoc::html::write(&mut rendered, &torture_document()).expect("failed to render HTML");
+    let html = String::from_utf8(rendered).expect("HTML output is not UTF-8");
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("snapshots/markdown");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        insta::assert_snapshot!("definition-lists-torture.html", html);
+    });
+}
+
+#[test]
+fn torture_fixture_gemini_snapshot() {
+    // Gemtext has no definition-list construct, so this snapshot is the record
+    // of how the list degrades — terms on their own line, definitions indented.
+    let mut rendered = Vec::new();
+    tdoc::gemini::write(&mut rendered, &torture_document()).expect("failed to render Gemtext");
+    let gemtext = String::from_utf8(rendered).expect("Gemtext output is not UTF-8");
+
+    // Said out loud rather than left to be discovered in the snapshot: the
+    // Gemtext writer drops block content nested inside a quote or a list item,
+    // so the fixture's two nested lists do not appear. This is not specific to
+    // definition lists — a nested bullet list is dropped in the same positions —
+    // so it is recorded here, not treated as a definition-list bug. Whoever
+    // teaches the writer to handle nested blocks should delete this assertion.
+    assert!(
+        !gemtext.contains("A quoted definition list"),
+        "the Gemtext writer now keeps definition lists nested in a blockquote — good; \
+         update this test and the snapshot"
+    );
+    assert!(
+        !gemtext.contains("The definition sits inside the list item"),
+        "the Gemtext writer now keeps definition lists nested in a list item — good; \
+         update this test and the snapshot"
+    );
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("snapshots/markdown");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        insta::assert_snapshot!("definition-lists-torture.gmi", gemtext);
+    });
+}
+
+#[test]
+fn torture_fixture_terminal_snapshot() {
+    // The terminal renderer is what most users actually see. ASCII rather than
+    // ANSI, so the snapshot stays readable; `formatter`'s own unit tests cover
+    // the bold term escapes.
+    let mut rendered: Vec<u8> = Vec::new();
+    Formatter::new_ascii(&mut rendered)
+        .write_document(&torture_document())
+        .expect("failed to format the fixture");
+    let text = String::from_utf8(rendered).expect("terminal output is not UTF-8");
+
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_path("snapshots/markdown");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        insta::assert_snapshot!("definition-lists-torture.txt", text);
+    });
 }
 
 #[test]

--- a/tests/ftml_macro.rs
+++ b/tests/ftml_macro.rs
@@ -2,7 +2,7 @@ use tdoc::test_helpers::{
     b__, code__, code_block__, doc as doc_, h1_, i__, li_, link_, link__, link_text__, mark__, ol_,
     p_, p__, quote_, s__, span, u__, ul_,
 };
-use tdoc::{doc, ftml, Paragraph, Span, TableCell, TableRow};
+use tdoc::{doc, ftml, DefinitionItem, Paragraph, Span, TableCell, TableRow};
 
 #[test]
 fn builds_document_trees() {
@@ -130,6 +130,39 @@ fn doc_supports_horizontal_rules() {
         Paragraph::new_horizontal_rule(),
         p__("Below"),
     ]);
+
+    assert_eq!(document, expected);
+}
+
+#[test]
+fn doc_supports_definition_lists() {
+    // Definition lists are a `doc!` extension (not strict FTML), like tables.
+    let document = doc! {
+        dl {
+            item {
+                term { "HTTP" }
+                def { p { "HyperText Transfer Protocol" } }
+            }
+            item {
+                term { "TCP" }
+                term { "UDP" }
+                def { p { "Transport protocols" } }
+            }
+        }
+    };
+
+    let expected = doc_(vec![Paragraph::new_definition_list()
+        .with_definition_items(vec![
+            DefinitionItem::new()
+                .with_terms(vec![vec![Span::new_text("HTTP")]])
+                .with_definition(vec![p__("HyperText Transfer Protocol")]),
+            DefinitionItem::new()
+                .with_terms(vec![
+                    vec![Span::new_text("TCP")],
+                    vec![Span::new_text("UDP")],
+                ])
+                .with_definition(vec![p__("Transport protocols")]),
+        ])]);
 
     assert_eq!(document, expected);
 }

--- a/tests/snapshots/html/convert-markdown/mdn-dl-element.snap
+++ b/tests/snapshots/html/convert-markdown/mdn-dl-element.snap
@@ -1,0 +1,6 @@
+---
+source: tests/html_import.rs
+expression: rendered
+extension: md
+snapshot_kind: binary
+---

--- a/tests/snapshots/html/convert-markdown/mdn-dl-element.snap.md
+++ b/tests/snapshots/html/convert-markdown/mdn-dl-element.snap.md
@@ -1,0 +1,77 @@
+# &lt;dl>: The Description List element
+
+The `<dl>` HTML element represents a description list. The element encloses a
+list of groups of terms (specified using the `<dt>` element) and descriptions
+(provided by `<dd>` elements). Common uses for this element are to implement a
+glossary or to display metadata (a list of key-value pairs).
+
+## Glossary
+
+Cryptids of Cornwall:
+
+Beast of Bodmin
+: A large feline inhabiting Bodmin Moor.
+
+Morgawr
+: A sea serpent.
+
+Owlman
+: A giant owl-like creature.
+
+## Single term and description
+
+Firefox
+: A free, open source, cross-platform, graphical web browser developed by the
+  Mozilla Corporation and hundreds of volunteers.
+
+## Multiple terms, single description
+
+Firefox
+Mozilla Firefox
+Fx
+: A free, open source, cross-platform, graphical web browser developed by the
+  Mozilla Corporation and hundreds of volunteers.
+
+## Single term, multiple descriptions
+
+Firefox
+: A free, open source, cross-platform, graphical web browser developed by the
+  Mozilla Corporation and hundreds of volunteers.
+  
+  The Red Panda also known as the Lesser Panda, Wah, Bear Cat or Firefox, is a
+  mostly herbivorous mammal, slightly larger than a domestic cat (60 cm long).
+
+## Metadata
+
+Description lists are useful for displaying metadata as a list of key-value
+pairs.
+
+Name
+: Godzilla
+
+Born
+: 1952
+
+Birthplace
+: Japan
+
+Color
+: Green
+
+## Wrapping name-value groups in div elements
+
+HTML allows wrapping each name-value group in a `<dl>` element in a `<div>`
+element. This can be useful when using microdata, or when global attributes
+apply to a whole group, or for styling purposes.
+
+Name
+: Godzilla
+
+Born
+: 1952
+
+Birthplace
+: Japan
+
+Color
+: Green

--- a/tests/snapshots/html/convert-text/mdn-dl-element.snap
+++ b/tests/snapshots/html/convert-text/mdn-dl-element.snap
@@ -1,0 +1,6 @@
+---
+source: tests/html_import.rs
+expression: rendered
+extension: txt
+snapshot_kind: binary
+---

--- a/tests/snapshots/html/convert-text/mdn-dl-element.snap.txt
+++ b/tests/snapshots/html/convert-text/mdn-dl-element.snap.txt
@@ -1,0 +1,108 @@
+
+
+
+                   <dl>: The Description List element
+
+
+
+The <dl> HTML element represents a description list. The element
+encloses a list of groups of terms (specified using the <dt> element)
+and descriptions (provided by <dd> elements). Common uses for this
+element are to implement a glossary or to display metadata (a list of
+key-value pairs).
+
+
+
+Glossary
+========
+
+
+Cryptids of Cornwall:
+
+Beast of Bodmin
+    A large feline inhabiting Bodmin Moor.
+
+Morgawr
+    A sea serpent.
+
+Owlman
+    A giant owl-like creature.
+
+
+
+Single term and description
+===========================
+
+
+Firefox
+    A free, open source, cross-platform, graphical web browser developed
+    by the Mozilla Corporation and hundreds of volunteers.
+
+
+
+Multiple terms, single description
+==================================
+
+
+Firefox
+Mozilla Firefox
+Fx
+    A free, open source, cross-platform, graphical web browser developed
+    by the Mozilla Corporation and hundreds of volunteers.
+
+
+
+Single term, multiple descriptions
+==================================
+
+
+Firefox
+    A free, open source, cross-platform, graphical web browser developed
+    by the Mozilla Corporation and hundreds of volunteers.
+    
+    The Red Panda also known as the Lesser Panda, Wah, Bear Cat or
+    Firefox, is a mostly herbivorous mammal, slightly larger than a
+    domestic cat (60 cm long).
+
+
+
+Metadata
+========
+
+
+Description lists are useful for displaying metadata as a list of
+key-value pairs.
+
+Name
+    Godzilla
+
+Born
+    1952
+
+Birthplace
+    Japan
+
+Color
+    Green
+
+
+
+Wrapping name-value groups in div elements
+==========================================
+
+
+HTML allows wrapping each name-value group in a <dl> element in a <div>
+element. This can be useful when using microdata, or when global
+attributes apply to a whole group, or for styling purposes.
+
+Name
+    Godzilla
+
+Born
+    1952
+
+Birthplace
+    Japan
+
+Color
+    Green

--- a/tests/snapshots/html/import/mdn-dl-element.snap
+++ b/tests/snapshots/html/import/mdn-dl-element.snap
@@ -1,0 +1,6 @@
+---
+source: tests/html_import.rs
+expression: rendered
+extension: ftml
+snapshot_kind: binary
+---

--- a/tests/snapshots/html/import/mdn-dl-element.snap.ftml
+++ b/tests/snapshots/html/import/mdn-dl-element.snap.ftml
@@ -1,0 +1,105 @@
+<h1>&lt;dl>: The Description List element</h1>
+
+<p>
+  The <code>&lt;dl></code> HTML element represents a description list. The element encloses a list of
+  groups of terms (specified using the <code>&lt;dt></code> element) and descriptions (provided by <code>&lt;dd></code> elements). Common uses for this element are to implement a glossary or to
+  display metadata (a list of key-value pairs).
+</p>
+
+<h2>Glossary</h2>
+
+<p>Cryptids of Cornwall:</p>
+
+<p>Beast of Bodmin</p>
+
+<p>A large feline inhabiting Bodmin Moor.</p>
+
+<p>Morgawr</p>
+
+<p>A sea serpent.</p>
+
+<p>Owlman</p>
+
+<p>A giant owl-like creature.</p>
+
+<h2>Single term and description</h2>
+
+<p>Firefox</p>
+
+<p>
+  A free, open source, cross-platform, graphical web browser developed by the
+  Mozilla Corporation and hundreds of volunteers.
+</p>
+
+<h2>Multiple terms, single description</h2>
+
+<p>Firefox</p>
+
+<p>Mozilla Firefox</p>
+
+<p>Fx</p>
+
+<p>
+  A free, open source, cross-platform, graphical web browser developed by the
+  Mozilla Corporation and hundreds of volunteers.
+</p>
+
+<h2>Single term, multiple descriptions</h2>
+
+<p>Firefox</p>
+
+<p>
+  A free, open source, cross-platform, graphical web browser developed by the
+  Mozilla Corporation and hundreds of volunteers.
+</p>
+
+<p>
+  The Red Panda also known as the Lesser Panda, Wah, Bear Cat or Firefox, is a
+  mostly herbivorous mammal, slightly larger than a domestic cat (60 cm long).
+</p>
+
+<h2>Metadata</h2>
+
+<p>
+  Description lists are useful for displaying metadata as a list of key-value
+  pairs.
+</p>
+
+<p>Name</p>
+
+<p>Godzilla</p>
+
+<p>Born</p>
+
+<p>1952</p>
+
+<p>Birthplace</p>
+
+<p>Japan</p>
+
+<p>Color</p>
+
+<p>Green</p>
+
+<h2>Wrapping name-value groups in div elements</h2>
+
+<p>
+  HTML allows wrapping each name-value group in a <code>&lt;dl></code> element in a <code>&lt;div></code> element. This can be useful when using microdata, or when global attributes
+  apply to a whole group, or for styling purposes.
+</p>
+
+<p>Name</p>
+
+<p>Godzilla</p>
+
+<p>Born</p>
+
+<p>1952</p>
+
+<p>Birthplace</p>
+
+<p>Japan</p>
+
+<p>Color</p>
+
+<p>Green</p>

--- a/tests/snapshots/markdown/definition-lists-markdown-extra.html.snap
+++ b/tests/snapshots/markdown/definition-lists-markdown-extra.html.snap
@@ -117,7 +117,7 @@ expression: html
 
     <pre>
 code block.
-    </pre>
+</pre>
 
     <blockquote>
       <p>block quote on two lines.</p>

--- a/tests/snapshots/markdown/definition-lists-markdown-extra.html.snap
+++ b/tests/snapshots/markdown/definition-lists-markdown-extra.html.snap
@@ -1,0 +1,136 @@
+---
+source: tests/definition_lists.rs
+expression: html
+---
+<h1>Definition Lists</h1>
+
+<p>
+  Markdown Extra implements definition lists. Definition lists are made of
+  terms and definitions of these terms, much like in a dictionary.
+</p>
+
+<p>
+  A simple definition list in Markdown Extra is made of a single-line term
+  followed by a colon and the definition for that term.
+</p>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</dd>
+  <dt>Orange</dt>
+  <dd>The fruit of an evergreen tree of the genus Citrus.</dd>
+</dl>
+
+<h2>Lazy continuation</h2>
+
+<p>
+  Terms must be separated from the previous definition by a blank line.
+  Definitions can span on multiple lines, in which case they should be
+  indented. But you don't really have to: if you want to be lazy, you could
+  forget to indent a definition that span on multiple lines and it will still
+  work:
+</p>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</dd>
+  <dt>Orange</dt>
+  <dd>The fruit of an evergreen tree of the genus Citrus.</dd>
+</dl>
+
+<h2>Several definitions for one term</h2>
+
+<p>
+  Colons as definition markers typically start at the left margin, but may be
+  indented by up to three spaces. Definition markers must be followed by one or
+  more spaces or a tab.
+</p>
+
+<p>
+  Definition lists can have more than one definition associated with one term:
+</p>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>
+    <p>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</p>
+
+    <p>An American computer company.</p>
+  </dd>
+  <dt>Orange</dt>
+  <dd>The fruit of an evergreen tree of the genus Citrus.</dd>
+</dl>
+
+<h2>Several terms for one definition</h2>
+
+<p>You can also associate more than one term to a definition:</p>
+
+<dl>
+  <dt>Term 1 Term 2</dt>
+  <dd>Definition a</dd>
+  <dt>Term 3</dt>
+  <dd>Definition b</dd>
+</dl>
+
+<h2>Loose definitions</h2>
+
+<p>
+  If a definition is preceded by a blank line, Markdown Extra will wrap the
+  definition in <code>&lt;p></code> tags in the HTML output. For example, this:
+</p>
+
+<dl>
+  <dt>Apple</dt>
+  <dd>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</dd>
+  <dt>Orange</dt>
+  <dd>The fruit of an evergreen tree of the genus Citrus.</dd>
+</dl>
+
+<h2>Block-level content in definitions</h2>
+
+<p>
+  And just like regular list items, definitions can contain multiple
+  paragraphs, and include other block-level elements such as blockquotes, code
+  blocks, lists, and even other definition lists.
+</p>
+
+<dl>
+  <dt>Term 1</dt>
+  <dd>
+    <p>
+      This is a definition with two paragraphs. Lorem ipsum dolor sit amet,
+      consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+    </p>
+
+    <p>
+      Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+    </p>
+
+    <p>
+      Second definition for term 1, also wrapped in a paragraph because of the
+      blank line preceding it.
+    </p>
+  </dd>
+  <dt>Term 2</dt>
+  <dd>
+    <p>This definition has a code block, a blockquote and a list.</p>
+
+    <pre>
+code block.
+    </pre>
+
+    <blockquote>
+      <p>block quote on two lines.</p>
+    </blockquote>
+
+    <ol>
+      <li>
+        <p>first list item</p>
+      </li>
+
+      <li>
+        <p>second list item</p>
+      </li>
+    </ol>
+  </dd>
+</dl>

--- a/tests/snapshots/markdown/definition-lists-torture.gmi.snap
+++ b/tests/snapshots/markdown/definition-lists-torture.gmi.snap
@@ -1,0 +1,81 @@
+---
+source: tests/definition_lists.rs
+expression: gemtext
+---
+# Definition list torture test
+
+Every definition-list shape the Markdown importer has to handle, in one document, so that a regression shows up as a diff rather than as a bug report. Each section is a separate list; the headings keep them apart.
+
+## One term, one definition
+
+Coffee
+  A hot black beverage
+
+## A definition of several paragraphs
+
+Firmware
+  Software written to a device's non-volatile memory.
+  Because it ships with the hardware, it is updated far less often than the software running on top of it.
+
+## A list inside a definition
+
+Prerequisites
+  You will need:
+  * a Rust toolchain
+  * ten minutes
+
+## An indented code block inside a definition
+
+Layout
+  The definition opens on the next line.
+     fn main() {}
+
+## A fenced code block, a quote, and a trailing paragraph
+
+Usage
+  Invoke the binary with a path:
+  Output goes to the pager unless --output is given.
+  println!("hello");
+  That is the whole interface.
+
+## Several descriptions folding into one definition
+
+Milk
+  A cold white beverage
+  Best served chilled
+
+## A definition separated from its term by a blank line
+
+Latency
+  The delay before a transfer begins.
+
+## The tilde marker, which is deliberately not supported
+
+Strikethrough ~ Some dialects accept ~ as a description marker. tdoc does not, because pulldown-cmark spends ~ on strikethrough.
+
+## Inline styles in terms and definitions
+
+--no-ansi
+  Disable ANSI escapes. Useful when the terminal is very old, or when piping into a file.
+FTML
+  The strict subset, described in the README.
+
+## Nested in a blockquote
+
+> Quoted intro.
+> 
+
+## Nested in a list item
+
+* An item with its own list: 
+* A plain second item.
+
+## Two lists separated only by a paragraph
+
+First
+  Ends here.
+
+An intervening paragraph, which keeps the two lists apart.
+
+Second
+  Starts here.

--- a/tests/snapshots/markdown/definition-lists-torture.html.snap
+++ b/tests/snapshots/markdown/definition-lists-torture.html.snap
@@ -1,0 +1,161 @@
+---
+source: tests/definition_lists.rs
+expression: html
+---
+<h1>Definition list torture test</h1>
+
+<p>
+  Every definition-list shape the Markdown importer has to handle, in one
+  document, so that a regression shows up as a diff rather than as a bug
+  report. Each section is a separate list; the headings keep them apart.
+</p>
+
+<h2>One term, one definition</h2>
+
+<dl>
+  <dt>Coffee</dt>
+  <dd>A hot black beverage</dd>
+</dl>
+
+<h2>A definition of several paragraphs</h2>
+
+<dl>
+  <dt>Firmware</dt>
+  <dd>
+    <p>Software written to a device's non-volatile memory.</p>
+
+    <p>
+      Because it ships with the hardware, it is updated far less often than the
+      software running on top of it.
+    </p>
+  </dd>
+</dl>
+
+<h2>A list inside a definition</h2>
+
+<dl>
+  <dt>Prerequisites</dt>
+  <dd>
+    <p>You will need:</p>
+
+    <ul>
+      <li>
+        <p>a Rust toolchain</p>
+      </li>
+
+      <li>
+        <p>ten minutes</p>
+      </li>
+    </ul>
+  </dd>
+</dl>
+
+<h2>An indented code block inside a definition</h2>
+
+<dl>
+  <dt>Layout</dt>
+  <dd>
+    <p>The definition opens on the next line.</p>
+
+    <pre>
+   fn main() {}
+    </pre>
+  </dd>
+</dl>
+
+<h2>A fenced code block, a quote, and a trailing paragraph</h2>
+
+<dl>
+  <dt>Usage</dt>
+  <dd>
+    <p>Invoke the binary with a path:</p>
+
+    <blockquote>
+      <p>Output goes to the pager unless <code>--output</code> is given.</p>
+    </blockquote>
+
+    <pre>
+println!("hello");
+    </pre>
+
+    <p>That is the whole interface.</p>
+  </dd>
+</dl>
+
+<h2>Several descriptions folding into one definition</h2>
+
+<dl>
+  <dt>Milk</dt>
+  <dd>
+    <p>A cold white beverage</p>
+
+    <p>Best served chilled</p>
+  </dd>
+</dl>
+
+<h2>A definition separated from its term by a blank line</h2>
+
+<dl>
+  <dt>Latency</dt>
+  <dd>The delay before a transfer begins.</dd>
+</dl>
+
+<h2>The tilde marker, which is deliberately not supported</h2>
+
+<p>
+  Strikethrough ~ Some dialects accept <code>~</code> as a description marker. tdoc does not, because pulldown-cmark spends <code>~</code> on strikethrough.
+</p>
+
+<h2>Inline styles in terms and definitions</h2>
+
+<dl>
+  <dt><code>--no-ansi</code></dt>
+  <dd>
+    Disable ANSI escapes. Useful when the terminal is <i>very</i> old, or when piping into a file.
+  </dd>
+  <dt><b>FTML</b></dt>
+  <dd>
+    The strict subset, described in the <a href="https://example.com/readme">README</a>.
+  </dd>
+</dl>
+
+<h2>Nested in a blockquote</h2>
+
+<blockquote>
+  <p>Quoted intro.</p>
+
+  <dl>
+    <dt>Blockquote</dt>
+    <dd>A quoted definition list.</dd>
+  </dl>
+</blockquote>
+
+<h2>Nested in a list item</h2>
+
+<ul>
+  <li>
+    <p>An item with its own list:</p>
+    <dl>
+      <dt>Item</dt>
+      <dd>The definition sits inside the list item.</dd>
+    </dl>
+  </li>
+
+  <li>
+    <p>A plain second item.</p>
+  </li>
+</ul>
+
+<h2>Two lists separated only by a paragraph</h2>
+
+<dl>
+  <dt>First</dt>
+  <dd>Ends here.</dd>
+</dl>
+
+<p>An intervening paragraph, which keeps the two lists apart.</p>
+
+<dl>
+  <dt>Second</dt>
+  <dd>Starts here.</dd>
+</dl>

--- a/tests/snapshots/markdown/definition-lists-torture.html.snap
+++ b/tests/snapshots/markdown/definition-lists-torture.html.snap
@@ -59,7 +59,7 @@ expression: html
 
     <pre>
    fn main() {}
-    </pre>
+</pre>
   </dd>
 </dl>
 
@@ -76,7 +76,7 @@ expression: html
 
     <pre>
 println!("hello");
-    </pre>
+</pre>
 
     <p>That is the whole interface.</p>
   </dd>

--- a/tests/snapshots/markdown/definition-lists-torture.md.snap
+++ b/tests/snapshots/markdown/definition-lists-torture.md.snap
@@ -1,0 +1,103 @@
+---
+source: tests/definition_lists.rs
+expression: rendered
+---
+# Definition list torture test
+
+Every definition-list shape the Markdown importer has to handle, in one
+document, so that a regression shows up as a diff rather than as a bug report.
+Each section is a separate list; the headings keep them apart.
+
+## One term, one definition
+
+Coffee
+: A hot black beverage
+
+## A definition of several paragraphs
+
+Firmware
+: Software written to a device's non-volatile memory.
+  
+  Because it ships with the hardware, it is updated far less often than the
+  software running on top of it.
+
+## A list inside a definition
+
+Prerequisites
+: You will need:
+  
+  - a Rust toolchain
+  - ten minutes
+
+## An indented code block inside a definition
+
+Layout
+: The definition opens on the next line.
+  
+  ```
+     fn main() {}
+  ```
+
+## A fenced code block, a quote, and a trailing paragraph
+
+Usage
+: Invoke the binary with a path:
+  
+  > Output goes to the pager unless `--output` is given.
+  
+  ```
+  println!("hello");
+  ```
+  
+  That is the whole interface.
+
+## Several descriptions folding into one definition
+
+Milk
+: A cold white beverage
+  
+  Best served chilled
+
+## A definition separated from its term by a blank line
+
+Latency
+: The delay before a transfer begins.
+
+## The tilde marker, which is deliberately not supported
+
+Strikethrough \~ Some dialects accept `~` as a description marker. tdoc does
+not, because pulldown-cmark spends `~` on strikethrough.
+
+## Inline styles in terms and definitions
+
+`--no-ansi`
+: Disable ANSI escapes. Useful when the terminal is _very_ old, or when piping
+  into a file.
+
+**FTML**
+: The strict subset, described in the [README](https://example.com/readme).
+
+## Nested in a blockquote
+
+> Quoted intro.
+> 
+> Blockquote
+> : A quoted definition list.
+
+## Nested in a list item
+
+- An item with its own list:
+  
+  Item
+  : The definition sits inside the list item.
+- A plain second item.
+
+## Two lists separated only by a paragraph
+
+First
+: Ends here.
+
+An intervening paragraph, which keeps the two lists apart.
+
+Second
+: Starts here.

--- a/tests/snapshots/markdown/definition-lists-torture.txt.snap
+++ b/tests/snapshots/markdown/definition-lists-torture.txt.snap
@@ -1,0 +1,156 @@
+---
+source: tests/definition_lists.rs
+expression: text
+---
+                      Definition list torture test
+
+
+
+Every definition-list shape the Markdown importer has to handle, in one
+document, so that a regression shows up as a diff rather than as a bug
+report. Each section is a separate list; the headings keep them apart.
+
+
+
+One term, one definition
+========================
+
+
+Coffee
+    A hot black beverage
+
+
+
+A definition of several paragraphs
+==================================
+
+
+Firmware
+    Software written to a device's non-volatile memory.
+    
+    Because it ships with the hardware, it is updated far less often
+    than the software running on top of it.
+
+
+
+A list inside a definition
+==========================
+
+
+Prerequisites
+    You will need:
+    
+     • a Rust toolchain
+    
+     • ten minutes
+
+
+
+An indented code block inside a definition
+==========================================
+
+
+Layout
+    The definition opens on the next line.
+    
+    --------------------------------------------------------------------
+       fn main() {}
+    --------------------------------------------------------------------
+
+
+
+A fenced code block, a quote, and a trailing paragraph
+======================================================
+
+
+Usage
+    Invoke the binary with a path:
+    
+    | Output goes to the pager unless --output is given.
+    
+    --------------------------------------------------------------------
+    println!("hello");
+    --------------------------------------------------------------------
+    
+    That is the whole interface.
+
+
+
+Several descriptions folding into one definition
+================================================
+
+
+Milk
+    A cold white beverage
+    
+    Best served chilled
+
+
+
+A definition separated from its term by a blank line
+====================================================
+
+
+Latency
+    The delay before a transfer begins.
+
+
+
+The tilde marker, which is deliberately not supported
+=====================================================
+
+
+Strikethrough ~ Some dialects accept ~ as a description marker. tdoc
+does not, because pulldown-cmark spends ~ on strikethrough.
+
+
+
+Inline styles in terms and definitions
+======================================
+
+
+--no-ansi
+    Disable ANSI escapes. Useful when the terminal is very old, or when
+    piping into a file.
+
+FTML
+    The strict subset, described in the README¹.
+
+¹ https://example.com/readme
+
+
+Nested in a blockquote
+======================
+
+
+| Quoted intro.
+| 
+| Blockquote
+|     A quoted definition list.
+
+
+
+Nested in a list item
+=====================
+
+
+ • An item with its own list:
+   
+   Item
+       The definition sits inside the list item.
+
+ • A plain second item.
+
+
+
+Two lists separated only by a paragraph
+=======================================
+
+
+First
+    Ends here.
+
+An intervening paragraph, which keeps the two lists apart.
+
+Second
+    Starts here.

--- a/tests/snapshots/markdown/definition_lists_spec.snap
+++ b/tests/snapshots/markdown/definition_lists_spec.snap
@@ -1,0 +1,531 @@
+---
+source: tests/definition_lists.rs
+expression: report
+---
+=== case 1 ===
+--- input ---
+apple
+:   red fruit
+
+orange
+:   orange fruit
+--- tdoc markdown ---
+apple
+: red fruit
+
+orange
+: orange fruit
+
+=== case 2 ===
+--- input ---
+apple
+
+:   red fruit
+
+orange
+
+:   orange fruit
+--- tdoc markdown ---
+apple
+: red fruit
+
+orange
+: orange fruit
+
+=== case 3 ===
+--- input ---
+apple
+
+:   red fruit
+--- tdoc markdown ---
+apple
+: red fruit
+
+=== case 4 ===
+--- input ---
+apple
+  : red fruit
+
+orange
+  : orange fruit
+--- tdoc markdown ---
+apple
+: red fruit
+
+orange
+: orange fruit
+
+=== case 5 ===
+--- input ---
+apple
+
+ : red fruit
+
+orange
+
+ : orange fruit
+--- tdoc markdown ---
+apple
+: red fruit
+
+orange
+: orange fruit
+
+=== case 6 ===
+--- input ---
+*apple*
+
+:   red fruit
+
+    contains seeds,
+    crisp, pleasant to taste
+
+*orange*
+
+:   orange fruit
+
+        { orange code block }
+
+    > orange block quote
+--- tdoc markdown ---
+_apple_
+: red fruit
+  
+  contains seeds, crisp, pleasant to taste
+
+_orange_
+: orange fruit
+  
+  ```
+  { orange code block }
+  ```
+  
+  > orange block quote
+
+=== case 7 ===
+--- input ---
+term
+
+:   1. Para one
+
+       Para two
+--- tdoc markdown ---
+term
+: 
+  1. Para one
+     
+     Para two
+
+=== case 8 ===
+--- input ---
+apple
+:   red fruit
+:   computer company
+
+orange
+:   orange fruit
+:   telecom company
+--- tdoc markdown ---
+apple
+: red fruit
+  
+  computer company
+
+orange
+: orange fruit
+  
+  telecom company
+
+=== case 9 ===
+--- input ---
+apple
+
+:   red fruit
+
+:   computer company
+
+orange
+
+:   orange fruit
+:   telecom company
+--- tdoc markdown ---
+apple
+: red fruit
+  
+  computer company
+
+orange
+: orange fruit
+  
+  telecom company
+
+=== case 10 ===
+--- input ---
+apple
+
+:   red fruit
+
+:   computer
+company
+
+orange
+
+:   orange
+fruit
+:   telecom company
+--- tdoc markdown ---
+apple
+: red fruit
+  
+  computer company
+
+orange
+: orange fruit
+  
+  telecom company
+
+=== case 11 ===
+--- input ---
+apple
+   : > computer company
+     : red fruit
+
+orange
+   : > telecom company
+   : orange fruit
+
+chili's
+   : > restaurant company
+ : spicy fruit
+--- tdoc markdown ---
+apple
+: > computer company : red fruit
+
+orange
+: > telecom company
+  
+  orange fruit
+
+chili's
+: > restaurant company
+  
+  spicy fruit
+
+=== case 12 ===
+--- input ---
+> cherry
+> : keyboard company
+> pomegranate
+: tart fruit
+--- tdoc markdown ---
+> cherry
+> : keyboard company pomegranate : tart fruit
+
+=== case 13 ===
+--- input ---
+a
+b\
+c
+
+:   foo
+--- tdoc markdown ---
+a b\
+c
+: foo
+
+=== case 14 ===
+--- input ---
+Foo
+
+bar
+:   baz
+
+bim
+:   bor
+--- tdoc markdown ---
+Foo
+
+bar
+: baz
+
+bim
+: bor
+
+=== case 15 ===
+--- input ---
+bar
+:   baz
+
+bim
+:   bor
+
+Bloze
+--- tdoc markdown ---
+bar
+: baz
+
+bim
+: bor
+
+Bloze
+
+=== case 16 ===
+--- input ---
+bar
+    :baz
+
+Bloze
+--- tdoc markdown ---
+bar :baz
+
+Bloze
+
+=== case 17 ===
+--- input ---
+bar
+:    baz
+
+Bloze
+--- tdoc markdown ---
+bar
+: baz
+
+Bloze
+
+=== case 18 ===
+--- input ---
+bar
+:       baz
+
+bar
+ :      baz
+
+bar
+  :     baz
+
+bar
+   :    baz
+
+bar
+    :   baz
+--- tdoc markdown ---
+bar
+: ```
+    baz
+  ```
+
+bar
+: ```
+   baz
+  ```
+
+bar
+: ```
+  baz
+  ```
+
+bar
+: baz
+
+bar :&emsp14;&emsp14;&emsp14;baz
+
+=== case 19 ===
+--- input ---
+*orange*
+
+:   orange fruit
+
+        { orange code block }
+
+  > orange block quote
+
+*orange*
+
+:     orange fruit
+
+        { orange code block }
+
+  > orange block quote
+--- tdoc markdown ---
+_orange_
+: orange fruit
+  
+  ```
+  { orange code block }
+  ```
+
+> orange block quote
+
+_orange_
+: ```
+  orange fruit
+  
+    { orange code block }
+  ```
+  
+  > orange block quote
+
+=== case 20 ===
+--- input ---
+Test|Table
+----|-----
+: first
+--- tdoc markdown ---
+| Test    | Table |
+|---------|-------|
+| : first |       |
+
+=== case 21 ===
+--- input ---
+first
+: second
+
+Test|Table
+----|-----
+: fourth
+--- tdoc markdown ---
+first
+: second
+
+| Test     | Table |
+|----------|-------|
+| : fourth |       |
+
+=== case 22 ===
+--- input ---
+My section
+==========
+: first
+--- tdoc markdown ---
+# My section
+
+\: first
+
+=== case 23 ===
+--- input ---
+first
+: second
+
+My section
+==========
+: fourth
+--- tdoc markdown ---
+first
+: second
+
+# My section
+
+\: fourth
+
+=== case 24 ===
+--- input ---
+## My subsection
+: first
+--- tdoc markdown ---
+## My subsection
+
+\: first
+
+=== case 25 ===
+--- input ---
+first
+: second
+
+## My subsection
+: fourth
+--- tdoc markdown ---
+first
+: second
+
+## My subsection
+
+\: fourth
+
+=== case 26 ===
+--- input ---
+> first
+: second
+--- tdoc markdown ---
+> first : second
+
+=== case 27 ===
+--- input ---
+first\
+: second
+
+third  
+: fourth
+--- tdoc markdown ---
+first\\
+: second
+
+third
+: fourth
+
+=== case 28 ===
+--- input ---
+<div>first</div>
+: second
+
+first
+: second
+<div>third</div>
+: fourth
+--- tdoc markdown ---
+&lt;div>first&lt;/div>\
+\: second\
+
+
+first
+: second
+
+&lt;div>third&lt;/div>\
+\: fourth\
+
+
+=== case 29 ===
+--- input ---
+<span>first</span>
+: second
+
+third
+: fourth
+
+<span>fifth</span>
+: sixth
+--- tdoc markdown ---
+&lt;span>first&lt;/span>
+: second
+
+third
+: fourth
+
+&lt;span>fifth&lt;/span>
+: sixth
+
+=== case 30 ===
+--- input ---
+level one
+: l1
+    level two
+    : l2
+        level three
+        : l3
+
+level one
+: l1
+--- tdoc markdown ---
+level one
+: l1 level two
+  : l2 level three
+    : l3
+
+level one
+: l1
+
+=== case 31 ===
+--- input ---
+[a]: /url
+    
+:
+--- tdoc markdown ---

--- a/tests/snapshots/markdown/import/definition-lists-markdown-extra.snap
+++ b/tests/snapshots/markdown/import/definition-lists-markdown-extra.snap
@@ -1,0 +1,6 @@
+---
+source: tests/markdown_import.rs
+expression: rendered
+extension: ftml
+snapshot_kind: binary
+---

--- a/tests/snapshots/markdown/import/definition-lists-markdown-extra.snap.ftml
+++ b/tests/snapshots/markdown/import/definition-lists-markdown-extra.snap.ftml
@@ -1,0 +1,130 @@
+<h1>Definition Lists</h1>
+
+<p>
+  Markdown Extra implements definition lists. Definition lists are made of
+  terms and definitions of these terms, much like in a dictionary.
+</p>
+
+<p>
+  A simple definition list in Markdown Extra is made of a single-line term
+  followed by a colon and the definition for that term.
+</p>
+
+<p>Apple</p>
+
+<p>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</p>
+
+<p>Orange</p>
+
+<p>The fruit of an evergreen tree of the genus Citrus.</p>
+
+<h2>Lazy continuation</h2>
+
+<p>
+  Terms must be separated from the previous definition by a blank line.
+  Definitions can span on multiple lines, in which case they should be
+  indented. But you don't really have to: if you want to be lazy, you could
+  forget to indent a definition that span on multiple lines and it will still
+  work:
+</p>
+
+<p>Apple</p>
+
+<p>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</p>
+
+<p>Orange</p>
+
+<p>The fruit of an evergreen tree of the genus Citrus.</p>
+
+<h2>Several definitions for one term</h2>
+
+<p>
+  Colons as definition markers typically start at the left margin, but may be
+  indented by up to three spaces. Definition markers must be followed by one or
+  more spaces or a tab.
+</p>
+
+<p>
+  Definition lists can have more than one definition associated with one term:
+</p>
+
+<p>Apple</p>
+
+<p>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</p>
+
+<p>An American computer company.</p>
+
+<p>Orange</p>
+
+<p>The fruit of an evergreen tree of the genus Citrus.</p>
+
+<h2>Several terms for one definition</h2>
+
+<p>You can also associate more than one term to a definition:</p>
+
+<p>Term 1 Term 2</p>
+
+<p>Definition a</p>
+
+<p>Term 3</p>
+
+<p>Definition b</p>
+
+<h2>Loose definitions</h2>
+
+<p>
+  If a definition is preceded by a blank line, Markdown Extra will wrap the
+  definition in <code>&lt;p></code> tags in the HTML output. For example, this:
+</p>
+
+<p>Apple</p>
+
+<p>Pomaceous fruit of plants of the genus Malus in the family Rosaceae.</p>
+
+<p>Orange</p>
+
+<p>The fruit of an evergreen tree of the genus Citrus.</p>
+
+<h2>Block-level content in definitions</h2>
+
+<p>
+  And just like regular list items, definitions can contain multiple
+  paragraphs, and include other block-level elements such as blockquotes, code
+  blocks, lists, and even other definition lists.
+</p>
+
+<p>Term 1</p>
+
+<p>
+  This is a definition with two paragraphs. Lorem ipsum dolor sit amet,
+  consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+</p>
+
+<p>Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.</p>
+
+<p>
+  Second definition for term 1, also wrapped in a paragraph because of the
+  blank line preceding it.
+</p>
+
+<p>Term 2</p>
+
+<p>This definition has a code block, a blockquote and a list.</p>
+
+<pre>
+code block.
+</pre>
+
+<blockquote>
+  <p>block quote on two lines.</p>
+</blockquote>
+
+<ol>
+  <li>
+    <p>first list item</p>
+  </li>
+
+  <li>
+    <p>second list item</p>
+  </li>
+</ol>

--- a/tests/snapshots/markdown/import/definition-lists-torture.snap
+++ b/tests/snapshots/markdown/import/definition-lists-torture.snap
@@ -1,0 +1,6 @@
+---
+source: tests/markdown_import.rs
+expression: rendered
+extension: ftml
+snapshot_kind: binary
+---

--- a/tests/snapshots/markdown/import/definition-lists-torture.snap.ftml
+++ b/tests/snapshots/markdown/import/definition-lists-torture.snap.ftml
@@ -1,0 +1,137 @@
+<h1>Definition list torture test</h1>
+
+<p>
+  Every definition-list shape the Markdown importer has to handle, in one
+  document, so that a regression shows up as a diff rather than as a bug
+  report. Each section is a separate list; the headings keep them apart.
+</p>
+
+<h2>One term, one definition</h2>
+
+<p>Coffee</p>
+
+<p>A hot black beverage</p>
+
+<h2>A definition of several paragraphs</h2>
+
+<p>Firmware</p>
+
+<p>Software written to a device's non-volatile memory.</p>
+
+<p>
+  Because it ships with the hardware, it is updated far less often than the
+  software running on top of it.
+</p>
+
+<h2>A list inside a definition</h2>
+
+<p>Prerequisites</p>
+
+<p>You will need:</p>
+
+<ul>
+  <li>
+    <p>a Rust toolchain</p>
+  </li>
+
+  <li>
+    <p>ten minutes</p>
+  </li>
+</ul>
+
+<h2>An indented code block inside a definition</h2>
+
+<p>Layout</p>
+
+<p>The definition opens on the next line.</p>
+
+<pre>
+   fn main() {}
+</pre>
+
+<h2>A fenced code block, a quote, and a trailing paragraph</h2>
+
+<p>Usage</p>
+
+<p>Invoke the binary with a path:</p>
+
+<blockquote>
+  <p>Output goes to the pager unless <code>--output</code> is given.</p>
+</blockquote>
+
+<pre>
+println!("hello");
+</pre>
+
+<p>That is the whole interface.</p>
+
+<h2>Several descriptions folding into one definition</h2>
+
+<p>Milk</p>
+
+<p>A cold white beverage</p>
+
+<p>Best served chilled</p>
+
+<h2>A definition separated from its term by a blank line</h2>
+
+<p>Latency</p>
+
+<p>The delay before a transfer begins.</p>
+
+<h2>The tilde marker, which is deliberately not supported</h2>
+
+<p>
+  Strikethrough ~ Some dialects accept <code>~</code> as a description marker. tdoc does not, because pulldown-cmark spends <code>~</code> on strikethrough.
+</p>
+
+<h2>Inline styles in terms and definitions</h2>
+
+<p><code>--no-ansi</code></p>
+
+<p>
+  Disable ANSI escapes. Useful when the terminal is <i>very</i> old, or when piping into a file.
+</p>
+
+<p><b>FTML</b></p>
+
+<p>
+  The strict subset, described in the <a href="https://example.com/readme">README</a>.
+</p>
+
+<h2>Nested in a blockquote</h2>
+
+<blockquote>
+  <p>Quoted intro.</p>
+
+  <p>Blockquote</p>
+
+  <p>A quoted definition list.</p>
+</blockquote>
+
+<h2>Nested in a list item</h2>
+
+<ul>
+  <li>
+    <p>An item with its own list:</p>
+    <p>Item</p>
+
+    <p>The definition sits inside the list item.</p>
+  </li>
+
+  <li>
+    <p>A plain second item.</p>
+  </li>
+</ul>
+
+<h2>Two lists separated only by a paragraph</h2>
+
+<p>First</p>
+
+<p>Ends here.</p>
+
+<p>An intervening paragraph, which keeps the two lists apart.</p>
+
+<p>Second</p>
+
+<p>Starts here.</p>


### PR DESCRIPTION
Adds definition lists as a first-class paragraph type, wired through every format tdoc reads and writes.

- Model: `Paragraph::DefinitionList` holding `DefinitionItems`, each pairing one or more terms with a single definition made of block paragraphs. Where a source gives the same term several definitions (multiple `<dd>`s, multiple `: ` lines), they fold into that one definition as consecutive paragraphs.
- Import: HTML `<dl>`/`<dt>`/`<dd>`, and the PHP Markdown Extra "Term" / "`: `definition" syntax.
- Export: Markdown and HTML round-trip losslessly within what each format can express. FTML has no `<dl>`, so terms and definition paragraphs flatten to `<p>`s, the same way tables do. Gemtext degrades to a term line with its definition indented beneath. The terminal formatter puts terms in bold at the left margin.
- `doc! { dl { item { term { … } def { … } } } }` builds one.